### PR TITLE
fix loading YAML config

### DIFF
--- a/lib/sidekiq-scheduler/cli.rb
+++ b/lib/sidekiq-scheduler/cli.rb
@@ -18,6 +18,7 @@ module SidekiqScheduler
         file_options = YAML.load_file(options[:config_file])
         options.merge!(file_options)
         options.delete(:config_file)
+        parse_queues(options, options.delete(:queues) || [])
       end
 
       scheduler = SidekiqScheduler::Manager.new(scheduler_options)


### PR DESCRIPTION
In original sidekiq on loading YML config:
$ bundle exec sidekiq -C config/sidekiq.yml
...
2013-06-06T09:49:23Z 20060 TID-nhf8c DEBUG: {:concurrency=>1, :require=>".", :environment=>nil, :timeout=>8, :profile=>false, :verbose=>true, :strict=>false, :tag=>"domain", :queues=>["high", "high", "default"]}

but in sidekiq-scheduler:
2013-06-06T09:48:40Z 20027 TID-mroos DEBUG: {:queues=>[["high", 2], ["default", 1]], :concurrency=>1, :require=>".", :environment=>nil, :timeout=>8, :profile=>false, :verbose=>true, :strict=>false, :tag=>"domain"}

so queues doesn't works
