### PR TITLE
Fix undefined method error

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -57,7 +57,7 @@ module SidekiqScheduler
     def print_schedule
       if rufus_scheduler
         Sidekiq.logger.info "Scheduling Info\tLast Run"
-        scheduler_jobs = rufus_scheduler.all_jobs
+        scheduler_jobs = rufus_scheduler.jobs
         scheduler_jobs.each_value do |v|
           Sidekiq.logger.info "#{v.t}\t#{v.last}\t"
         end


### PR DESCRIPTION
Rufus used `jobs` method instead of `all_jobs`
https://github.com/jmettraux/rufus-scheduler/blob/3fe5a02b4ceae7901228010a0b58e62a3be0e456/lib/rufus/scheduler.rb#L277