### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds Dependabot for GitHub Actions, ensuring that the action versions stay up to date.

Since the checkout action is currently out of date, if and when this is merged Dependabot will open a PR to update the action.