### PR TITLE
Allow for multiple applications to share a Redis DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,20 @@ Redis.
 
 See https://github.com/sidekiq-scheduler/sidekiq-scheduler/issues/361 for a more details.
 
+## Notes when running multiple applications in the same Redis database
+
+If you need to run multiple applications with differing schedules, the easiest way is to use a different Redis database per application. Doing that will ensure that each application will have its own schedule, web interface and statistics.
+
+However, you may want to have a set of related applications share the same Redis database in order to aggregate statistics and manage them all in a single web interface. To do this while maintaining a different schedule for each application, you can configure each application to use a different `key_prefix` in Redis. This prevents the applications overwriting each others' schedules and schedule data.
+
+```ruby
+Rails.application.reloader.to_prepare do
+  SidekiqScheduler::RedisManager.key_prefix = "my-app"
+end
+```
+
+Note that this must be set before the schedule is loaded (or it will go into the wrong key). If you are using the web integration, make sure that the prefix is set in the web process so that you see the correct schedule.
+
 ## Sidekiq Web Integration
 
 sidekiq-scheduler provides an extension to the Sidekiq web interface that adds a `Recurring Jobs` page.

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -9,7 +9,7 @@ module SidekiqScheduler
     #
     # @return [String] schedule in JSON format
     def self.get_job_schedule(name)
-      hget('schedules', name)
+      hget(schedules_key, name)
     end
 
     # Returns the state of a given job
@@ -44,7 +44,7 @@ module SidekiqScheduler
     # @param [String] name The name of the job
     # @param [Hash] config The new schedule for the job
     def self.set_job_schedule(name, config)
-      hset('schedules', name, JSON.generate(config))
+      hset(schedules_key, name, JSON.generate(config))
     end
 
     # Sets the state for a given job
@@ -75,7 +75,7 @@ module SidekiqScheduler
     #
     # @param [String] name The name of the job
     def self.remove_job_schedule(name)
-      hdel('schedules', name)
+      hdel(schedules_key, name)
     end
 
     # Removes the next execution time for a given job
@@ -89,14 +89,14 @@ module SidekiqScheduler
     #
     # @return [Hash] hash with all the job schedules
     def self.get_all_schedules
-      Sidekiq.redis { |r| r.hgetall('schedules') }
+      Sidekiq.redis { |r| r.hgetall(schedules_key) }
     end
 
     # Returns boolean value that indicates if the schedules value exists
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists?('schedules') }
+      Sidekiq.redis { |r| r.exists?(schedules_key) }
     end
 
     # Returns all the schedule changes for a given time range.
@@ -178,6 +178,13 @@ module SidekiqScheduler
     # @return [String] with the key
     def self.schedules_state_key
       'sidekiq-scheduler:states'
+    end
+
+    # Returns the Redis's key for saving schedules.
+    #
+    # @return [String] with the key
+    def self.schedules_key
+      'schedules'
     end
 
     private

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -106,19 +106,19 @@ module SidekiqScheduler
     #
     # @return [Array] array with all the changed job names
     def self.get_schedule_changes(from, to)
-      Sidekiq.redis { |r| r.zrangebyscore('schedules_changed', from, "(#{to}") }
+      Sidekiq.redis { |r| r.zrangebyscore(schedules_changed_key, from, "(#{to}") }
     end
 
     # Register a schedule change for a given job
     #
     # @param [String] name The name of the job
     def self.add_schedule_change(name)
-      Sidekiq.redis { |r| r.zadd('schedules_changed', Time.now.to_f, name) }
+      Sidekiq.redis { |r| r.zadd(schedules_changed_key, Time.now.to_f, name) }
     end
 
     # Remove all the schedule changes records
     def self.clean_schedules_changed
-      Sidekiq.redis { |r| r.del('schedules_changed') unless r.type('schedules_changed') == 'zset' }
+      Sidekiq.redis { |r| r.del(schedules_changed_key) unless r.type(schedules_changed_key) == 'zset' }
     end
 
     # Removes a queued job instance
@@ -185,6 +185,13 @@ module SidekiqScheduler
     # @return [String] with the key
     def self.schedules_key
       'schedules'
+    end
+
+    # Returns the Redis's key for saving schedule changes.
+    #
+    # @return [String] with the key
+    def self.schedules_changed_key
+      'schedules_changed'
     end
 
     private

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -156,42 +156,57 @@ module SidekiqScheduler
     #
     # @return [String] the pushed job key
     def self.pushed_job_key(job_name)
-      "sidekiq-scheduler:pushed:#{job_name}"
+      "#{key_prefix}sidekiq-scheduler:pushed:#{job_name}"
     end
 
     # Returns the key of the Redis hash for job's execution times hash
     #
     # @return [String] with the key
     def self.next_times_key
-      'sidekiq-scheduler:next_times'
+      "#{key_prefix}sidekiq-scheduler:next_times"
     end
 
     # Returns the key of the Redis hash for job's last execution times hash
     #
     # @return [String] with the key
     def self.last_times_key
-      'sidekiq-scheduler:last_times'
+      "#{key_prefix}sidekiq-scheduler:last_times"
     end
 
     # Returns the Redis's key for saving schedule states.
     #
     # @return [String] with the key
     def self.schedules_state_key
-      'sidekiq-scheduler:states'
+      "#{key_prefix}sidekiq-scheduler:states"
     end
 
     # Returns the Redis's key for saving schedules.
     #
     # @return [String] with the key
     def self.schedules_key
-      'schedules'
+      "#{key_prefix}schedules"
     end
 
     # Returns the Redis's key for saving schedule changes.
     #
     # @return [String] with the key
     def self.schedules_changed_key
-      'schedules_changed'
+      "#{key_prefix}schedules_changed"
+    end
+
+    # Returns the key prefix used to generate all scheduler keys
+    #
+    # @return [String] with the key prefix
+    def self.key_prefix
+      @key_prefix
+    end
+
+    # Sets the key prefix used to scope all scheduler keys
+    #
+    # @param [String] value The string to use as the prefix. A ":" will be appended as a delimiter if needed.
+    def self.key_prefix=(value)
+      value = "#{value}:" if value && !%w[. :].include?(value[-1])
+      @key_prefix = value
     end
 
     private

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -10,7 +10,7 @@ describe SidekiqScheduler::RedisManager do
     let(:job_name) { 'some_job' }
     let(:schedule) { JSON.generate(ScheduleFaker.default_options) }
 
-    before { SidekiqScheduler::Store.hset(:schedules, job_name, schedule) }
+    before { SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_key, job_name, schedule) }
 
     it { is_expected.to eq(schedule) }
   end
@@ -57,7 +57,7 @@ describe SidekiqScheduler::RedisManager do
     it 'should store the job schedule' do
       subject
 
-      stored_schedule = SidekiqScheduler::Store.hget(:schedules, job_name)
+      stored_schedule = SidekiqScheduler::Store.hget(SidekiqScheduler::RedisManager.schedules_key, job_name)
       expect(JSON.parse(stored_schedule)).to eq(config)
     end
   end
@@ -110,12 +110,12 @@ describe SidekiqScheduler::RedisManager do
     let(:job_name) { 'some_job' }
     let(:schedule) { JSON.generate(ScheduleFaker.default_options) }
 
-    before { SidekiqScheduler::Store.hset(:schedules, job_name, schedule) }
+    before { SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_key, job_name, schedule) }
 
     it 'should remove the job schedule' do
       subject
 
-      stored_schedule = SidekiqScheduler::Store.hget(:schedules, job_name)
+      stored_schedule = SidekiqScheduler::Store.hget(SidekiqScheduler::RedisManager.schedules_key, job_name)
       expect(stored_schedule).to be_nil
     end
 
@@ -125,7 +125,7 @@ describe SidekiqScheduler::RedisManager do
       it 'should maintain inexisting' do
         subject
 
-        stored_schedule = SidekiqScheduler::Store.hget(:schedules, job_name)
+        stored_schedule = SidekiqScheduler::Store.hget(SidekiqScheduler::RedisManager.schedules_key, job_name)
         expect(stored_schedule).to be_nil
       end
     end
@@ -167,8 +167,8 @@ describe SidekiqScheduler::RedisManager do
     let(:other_job_schedule) { JSON.generate(ScheduleFaker.every_schedule) }
 
     before do
-      SidekiqScheduler::Store.hset(:schedules, some_job, some_job_schedule)
-      SidekiqScheduler::Store.hset(:schedules, other_job, other_job_schedule)
+      SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_key, some_job, some_job_schedule)
+      SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_key, other_job, other_job_schedule)
     end
 
     it { is_expected.to include('some_job' => some_job_schedule, 'other_job' => other_job_schedule) }
@@ -183,7 +183,7 @@ describe SidekiqScheduler::RedisManager do
     context 'when some job schedule exists' do
       let(:schedule) { JSON.generate(ScheduleFaker.default_options) }
 
-      before { SidekiqScheduler::Store.hset(:schedules, 'some_job', schedule) }
+      before { SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_key, 'some_job', schedule) }
 
       it { is_expected.to be_truthy }
     end
@@ -361,5 +361,11 @@ describe SidekiqScheduler::RedisManager do
     subject { described_class.schedules_state_key }
 
     it { is_expected.to eq('sidekiq-scheduler:states') }
+  end
+
+  describe ".schedules_key" do
+    subject { described_class.schedules_key }
+
+    it { is_expected.to eq('schedules') }
   end
 end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -468,9 +468,9 @@ describe SidekiqScheduler::Scheduler do
     context 'when setting new values' do
       before do
         instance.load_schedule!
-        SidekiqScheduler::Store.del(:schedules)
+        SidekiqScheduler::Store.del(SidekiqScheduler::RedisManager.schedules_key)
         SidekiqScheduler::Store.hset(
-          :schedules,
+          SidekiqScheduler::RedisManager.schedules_key,
           'some_ivar_job2',
           JSON.generate(
             cron: '* * * * *',
@@ -495,7 +495,7 @@ describe SidekiqScheduler::Scheduler do
           }
         }
         instance.load_schedule!
-        SidekiqScheduler::Store.del(:schedules)
+        SidekiqScheduler::Store.del(SidekiqScheduler::RedisManager.schedules_key)
       end
 
       it 'should remove them' do

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -14,7 +14,7 @@ module SidekiqScheduler
     end
 
     def self.job_from_redis_without_decoding(job_id)
-      Sidekiq.redis { |redis| redis.hget('schedules', job_id) }
+      Sidekiq.redis { |redis| redis.hget(SidekiqScheduler::RedisManager.schedules_key, job_id) }
     end
 
     def self.job_next_execution_time(job_name)

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -10,7 +10,7 @@ module SidekiqScheduler
     end
 
     def self.changed_job?(job_id)
-      Sidekiq.redis { |redis| !!redis.zrank('schedules_changed', job_id) }
+      Sidekiq.redis { |redis| !!redis.zrank(SidekiqScheduler::RedisManager.schedules_changed_key, job_id) }
     end
 
     def self.job_from_redis_without_decoding(job_id)


### PR DESCRIPTION
Implements #400

Adds the ability to set a `key_prefix` which will be prepended to all Redis keys. This allows multiple applications to keep their schedules in the same Redis database without clobbering each other.

This change does not affect the runtime of the RSpec suite, but allows for the use case mentioned. Doing the first two commits without the last one would allow for monkey patches, but if we could do the whole thing that would be great.