### PR TITLE
Fix metadata for Sidekiq `strict_args!`

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -158,7 +158,7 @@ module SidekiqScheduler
       config = prepare_arguments(job_config.dup)
 
       if config.delete('include_metadata')
-        config['args'] = arguments_with_metadata(config['args'], scheduled_at: time.to_f)
+        config['args'] = arguments_with_metadata(config['args'], "scheduled_at" => time.to_f)
       end
 
       if SidekiqScheduler::Utils.active_job_enqueue?(config['class'])

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -189,7 +189,7 @@ describe SidekiqScheduler::Scheduler do
             expect(Sidekiq::Client).to receive(:push).with(
               'class' => SomeWorker,
               'queue' => 'high',
-              'args' => ['/tmp', { scheduled_at: schedule_time.to_f }]
+              'args' => ['/tmp', { 'scheduled_at' => schedule_time.to_f }]
             )
 
             subject
@@ -203,7 +203,7 @@ describe SidekiqScheduler::Scheduler do
             expect(Sidekiq::Client).to receive(:push).with(
               'class' => SomeWorker,
               'queue' => 'high',
-              'args' => ['/tmp', { scheduled_at: schedule_time.to_f }]
+              'args' => ['/tmp', { 'scheduled_at' => schedule_time.to_f }]
             )
 
             subject
@@ -217,7 +217,7 @@ describe SidekiqScheduler::Scheduler do
         it 'enqueues the job as active job' do
           expect(EmailSender).to receive(:new).with(
             '/tmp',
-            { scheduled_at: schedule_time.to_f }
+            { 'scheduled_at' => schedule_time.to_f }
           ).and_return(double(:job).as_null_object)
 
           subject
@@ -237,7 +237,7 @@ describe SidekiqScheduler::Scheduler do
             expect(Sidekiq::Client).to receive(:push).with(
               'class' => SomeWorker,
               'queue' => 'high',
-              'args' => [{ dir: '/tmp' }, { scheduled_at: schedule_time.to_f }]
+              'args' => [{ dir: '/tmp' }, { 'scheduled_at' => schedule_time.to_f }]
             )
 
             subject
@@ -253,7 +253,7 @@ describe SidekiqScheduler::Scheduler do
             expect(Sidekiq::Client).to receive(:push).with(
               'class' => SomeWorker,
               'queue' => 'high',
-              'args' => [{ scheduled_at: schedule_time.to_f }]
+              'args' => [{ 'scheduled_at' => schedule_time.to_f }]
             )
 
             subject


### PR DESCRIPTION
- update `scheduled_at` metadata to string key, hash rocket syntax
- update spec to expect string key, hash rocket syntax
- fixes issue #402 