### PR TITLE
Redis 5.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
+        redis-version: ">= 5"
         ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+      include:
+        - redis-version: "< 5"
+          ruby-version: "2.5"
+    services:
+      redis:
+        image: redis
+    env:
+      REDIS_URL: redis://redis
+      REDIS_VERSION: "${{ matrix.redis-version }}"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem "redis", ENV.fetch("REDIS_VERSION", ">= 5")
 gemspec

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -60,7 +60,7 @@ module SidekiqScheduler
     # @param [String] name The name of the job
     # @param [String] next_time The next time the job has to be executed
     def self.set_job_next_time(name, next_time)
-      hset(next_times_key, name, next_time)
+      hset(next_times_key, name, String(next_time))
     end
 
     # Sets the last execution time for a given job
@@ -68,7 +68,7 @@ module SidekiqScheduler
     # @param [String] name The name of the job
     # @param [String] last_time The last time the job was executed
     def self.set_job_last_time(name, last_time)
-      hset(last_times_key, name, last_time)
+      hset(last_times_key, name, String(last_time))
     end
 
     # Removes the schedule for a given job

--- a/lib/sidekiq-scheduler/utils.rb
+++ b/lib/sidekiq-scheduler/utils.rb
@@ -112,8 +112,10 @@ module SidekiqScheduler
     def self.new_rufus_scheduler(options = {})
       Rufus::Scheduler.new(options).tap do |scheduler|
         scheduler.define_singleton_method(:on_post_trigger) do |job, triggered_time|
-          SidekiqScheduler::Utils.update_job_last_time(job.tags[0], triggered_time)
-          SidekiqScheduler::Utils.update_job_next_time(job.tags[0], job.next_time)
+          if (job_name = job.tags[0])
+            SidekiqScheduler::Utils.update_job_last_time(job_name, triggered_time)
+            SidekiqScheduler::Utils.update_job_next_time(job_name, job.next_time)
+          end
         end
       end
     end

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'mock_redis', '~> 0.28.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'activejob'

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -297,9 +297,8 @@ describe SidekiqScheduler::RedisManager do
     it 'should add an expiration key' do
       subject
 
-      Timecop.travel(SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS) do
-        expect(SidekiqScheduler::Store.exists?('sidekiq-scheduler:pushed:some_job')).to be false
-      end
+      ttl = Sidekiq.redis { |r| r.ttl('sidekiq-scheduler:pushed:some_job') }
+      expect(ttl).to eql(SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
     end
 
     context 'when job instance is already registered' do

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -676,10 +676,10 @@ describe SidekiqScheduler::Scheduler do
     end
 
     context 'at schedule' do
-      let(:config) { ScheduleFaker.at_schedule }
+      let(:config) { ScheduleFaker.at_schedule(at: Time.now + 60) }
 
       it 'adds the job to rufus scheduler' do
-        expect(instance.rufus_scheduler.jobs.size).to be(1)
+        expect(instance.rufus_scheduler.jobs.size).to eq(1)
       end
 
       it 'puts the job inside the scheduled hash' do

--- a/spec/support/initialization/redis.rb
+++ b/spec/support/initialization/redis.rb
@@ -1,19 +1,7 @@
-require 'mock_redis'
 require 'sidekiq/redis_connection'
 
 RSpec.configure do |config|
   config.before do
-    redis = MockRedis.new
-
-    connection = {
-      location: '127.0.0.1:1234',
-      db: '0'
-    }
-
-    redis.define_singleton_method(:connection) { connection }
-
-    allow(Sidekiq::RedisConnection).to receive(:create).and_return(ConnectionPool.new({}) {
-      redis
-    })
+    Sidekiq.redis { |r| r.flushdb(async: true) }
   end
 end


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1143

- Remove `redis_mock` as it was hiding several bugs
- Explicitly cast time types to string, as redis-rb 5.0 no longer does it implicitly

