### PR TITLE
[WIP] Allow Sidekiq 7 to work with the gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix: 
         redis-version: ["~> 4.2", "~> 5"]
         ruby-version: ['2.7', '3.0', '3.1']
-        sidekiq-version: ['~> 6']
+        sidekiq-version: ['~> 6', '~> 7']
     services:
       redis:
         image: redis

--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -17,7 +17,7 @@ Sidekiq.configure_server do |config|
     SidekiqScheduler::RedisManager.clean_schedules_changed
 
     # Accessing the raw @config hash through .options is deprecated in 6.5 and to be removed in 7.0
-    config_options = SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options
+    config_options = SIDEKIQ_GTE_7_0_0 ? options.instance_variable_get(:@options) : (SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options)    
 
     schedule_manager = SidekiqScheduler::Manager.new(config_options)
     if SIDEKIQ_GTE_6_5_0

--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -8,6 +8,7 @@ require_relative 'sidekiq-scheduler/redis_manager'
 require_relative 'sidekiq-scheduler/extensions/schedule'
 
 SIDEKIQ_GTE_6_5_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+SIDEKIQ_GTE_7_0_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
 
 Sidekiq.configure_server do |config|
 

--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -17,7 +17,7 @@ Sidekiq.configure_server do |config|
     SidekiqScheduler::RedisManager.clean_schedules_changed
 
     # Accessing the raw @config hash through .options is deprecated in 6.5 and to be removed in 7.0
-    config_options = SIDEKIQ_GTE_7_0_0 ? options.instance_variable_get(:@options) : (SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options)    
+    config_options = SIDEKIQ_GTE_7_0_0 ? config.instance_variable_get(:@options) : (SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options)    
 
     schedule_manager = SidekiqScheduler::Manager.new(config_options)
     if SIDEKIQ_GTE_6_5_0

--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -36,8 +36,9 @@ module SidekiqScheduler
     private
 
     def load_scheduler_options(options)
-      options[:listened_queues_only] = options.fetch(:scheduler, {})[:listened_queues_only]
-      scheduler_options = DEFAULT_SCHEDULER_OPTIONS.merge(options)
+      hash_options = SIDEKIQ_GTE_7_0_0 ? options.instance_variable_get(:@options) : options
+      hash_options[:listened_queues_only] = hash_options.fetch(:scheduler, {})[:listened_queues_only]
+      scheduler_options = DEFAULT_SCHEDULER_OPTIONS.merge(hash_options)
 
       current_options = {
         enabled: SidekiqScheduler::Scheduler.enabled,

--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -36,9 +36,8 @@ module SidekiqScheduler
     private
 
     def load_scheduler_options(options)
-      hash_options = SIDEKIQ_GTE_7_0_0 ? options.instance_variable_get(:@options) : options
-      hash_options[:listened_queues_only] = hash_options.fetch(:scheduler, {})[:listened_queues_only]
-      scheduler_options = DEFAULT_SCHEDULER_OPTIONS.merge(hash_options)
+      options[:listened_queues_only] = options.fetch(:scheduler, {})[:listened_queues_only]
+      scheduler_options = DEFAULT_SCHEDULER_OPTIONS.merge(options)
 
       current_options = {
         enabled: SidekiqScheduler::Scheduler.enabled,

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,13 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists?(schedules_key) }
+      Sidekiq.redis do |r|
+        if SIDEKIQ_GTE_7_0_0
+          r.exists(schedules_key) > 0
+        else
+          r.exists?(schedules_key)
+        end
+      end
     end
 
     # Returns all the schedule changes for a given time range.
@@ -210,7 +216,7 @@ module SidekiqScheduler
     end
 
     private
-    
+
     # Returns the value of a Redis stored hash field
     #
     # @param [String] hash_key The key name of the hash

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -142,7 +142,7 @@ module SidekiqScheduler
         end
       end
 
-      registered
+      registered.instance_of?(Integer) ? registered == 1 : registered
     end
 
     # Removes instances of the job older than 24 hours

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -142,7 +142,7 @@ module SidekiqScheduler
         end
       end
 
-      registered.instance_of?(Integer) ? registered == 1 : registered
+      registered.instance_of?(Integer) ? (registered > 0) : registered
     end
 
     # Removes instances of the job older than 24 hours

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -292,7 +292,9 @@ module SidekiqScheduler
     end
 
     def sidekiq_queues
-      if SIDEKIQ_GTE_6_5_0
+      if SIDEKIQ_GTE_7_0_0
+        Sidekiq.instance_variable_get(:@config).queues.map(&:to_s)
+      elsif SIDEKIQ_GTE_6_5_0
         Sidekiq[:queues].map(&:to_s)
       else
         Sidekiq.options[:queues].map(&:to_s)

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,14 +16,14 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency 'sidekiq', '>= 6', '< 7'
-  s.add_dependency 'redis', '>= 4.2.0'
+  s.add_dependency 'sidekiq', '>= 4', '< 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0'
 
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
+  s.add_development_dependency 'redis', '>= 4.2.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'byebug'

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -574,7 +574,7 @@ describe SidekiqScheduler::Scheduler do
       end
 
       it 'does not store the next time execution correctly' do
-        expect(next_time_execution).to eq 0
+        expect(next_time_execution).not_to be
       end
     end
 
@@ -632,7 +632,7 @@ describe SidekiqScheduler::Scheduler do
           end
 
           it 'does not store the next time execution correctly' do
-            expect(next_time_execution).to eq 0
+            expect(next_time_execution).not_to be
           end
         end
       end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -579,7 +579,7 @@ describe SidekiqScheduler::Scheduler do
       end
 
       it 'does not store the next time execution correctly' do
-        expect(next_time_execution).not_to be
+        expect(next_time_execution).to eq 0
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 
 SimpleCov.start do
+  add_filter "spec/support/sidekiq.rb"
   minimum_coverage 97.91
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'sidekiq/testing'
 require 'sidekiq-scheduler'
 require 'json'
 require 'timecop'
+require 'byebug'
 
 # Load all support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,4 +1,6 @@
-require 'sidekiq/capsule'
+if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
+  require 'sidekiq/capsule'
+end
 
 def reset_sidekiq_config!
   cfg = Sidekiq::Config.new

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,9 @@
+require 'sidekiq/capsule'
+
+def reset_sidekiq_config!
+  cfg = Sidekiq::Config.new
+  cfg.logger = ::Logger.new("/dev/null")
+  cfg.logger.level = Logger::WARN
+  Sidekiq.instance_variable_set :@config, cfg
+  cfg
+end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -9,3 +9,23 @@ def reset_sidekiq_config!
   Sidekiq.instance_variable_set :@config, cfg
   cfg
 end
+
+class SConfigWrapper
+  def reset!
+    if SIDEKIQ_GTE_7_0_0
+      @sconfig = reset_sidekiq_config!
+      @sconfig.queues = []
+    else
+      # Sidekiq 6 the default queues was an empty array https://github.com/mperham/sidekiq/blob/6-x/lib/sidekiq.rb#L21
+      Sidekiq.options[:queues] = Sidekiq::DEFAULTS[:queues]
+    end
+  end
+
+  def queues=(val)
+    if SIDEKIQ_GTE_7_0_0
+      @sconfig.queues = val
+    else
+      Sidekiq.options[:queues] = val
+    end
+  end
+end

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -58,7 +58,7 @@ module SidekiqScheduler
     end
 
     def self.exists?(key)
-      Sidekiq.redis { |r| r.exists?(key) }
+      Sidekiq.redis { |r| SIDEKIQ_GTE_7_0_0 ? (r.exists(key) > 0) : r.exists?(key) }
     end
 
     def self.hexists(hash_key, field_key)

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -62,7 +62,8 @@ module SidekiqScheduler
     end
 
     def self.hexists(hash_key, field_key)
-      Sidekiq.redis { |r| r.hexists(hash_key.to_s, field_key.to_s) }
+      result = Sidekiq.redis { |r| r.hexists(hash_key.to_s, field_key.to_s) }
+      SIDEKIQ_GTE_7_0_0 ? (result > 0) : result
     end
   end
 end


### PR DESCRIPTION
Closes #409 

- Updated the sidekiq dependency in the gemspec.
- Changed the redis gem to be a development dependency.
- Added `SIDEKIQ_GTE_7_0_0` for version checks.
- Implemented changes needed to get sidekiq 7 playing nice using the new constant to fork logic.

I used a near vanilla Rails app with some simple jobs to verify sidekiq boots and scheduled jobs do enqueue and execute.