### PR TITLE
Drop support for EOL Rubies & Sidekiq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix: 
         redis-version: ["~> 4.2", "~> 5"]
         ruby-version: ['2.7', '3.0', '3.1']
+        sidekiq-version: ['~> 6']
     services:
       redis:
         image: redis
@@ -19,6 +20,7 @@ jobs:
           - 6379:6379
     env:
       REDIS_VERSION: "${{ matrix.redis-version }}"
+      SIDEKIQ_VERSION: "${{ matrix.sidekiq-version }}"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix: 
         redis-version: ["~> 4.2", "~> 5"]
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1']
     services:
       redis:
         image: redis

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem "redis", ENV.fetch("REDIS_VERSION", ">= 5")
+gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
 gemspec

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0'
 
-  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency 'sidekiq', '>= 4', '< 7'
+  s.add_dependency 'sidekiq', '>= 6', '< 7'
   s.add_dependency 'redis', '>= 4.2.0'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0'
 
-  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['{lib,web}/**/*'] + %w[MIT-LICENSE Rakefile README.md CHANGELOG.md]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_dependency 'sidekiq', '>= 4', '< 7'
   s.add_dependency 'redis', '>= 4.2.0'

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -133,9 +133,11 @@ describe SidekiqScheduler::Scheduler do
     context 'when it is a sidekiq worker' do
       it 'prepares the parameters' do
         expect(Sidekiq::Client).to receive(:push).with(
-          'class' => SomeWorker,
-          'queue' => 'high',
-          'args' => ['/tmp']
+          {
+            'class' => SomeWorker,
+            'queue' => 'high',
+            'args' => ['/tmp']
+          }
         )
 
         subject
@@ -170,11 +172,11 @@ describe SidekiqScheduler::Scheduler do
       before { scheduler_config['class'] = 'NonExistentWorker' }
 
       it 'prepares the parameters' do
-        expect(Sidekiq::Client).to receive(:push).with(
+        expect(Sidekiq::Client).to receive(:push).with({
           'class' => 'NonExistentWorker',
           'queue' => 'high',
           'args' => ['/tmp']
-        )
+        })
 
         subject
       end
@@ -186,11 +188,11 @@ describe SidekiqScheduler::Scheduler do
       context 'when called without a time argument' do
         it 'uses the current time' do
           Timecop.freeze(schedule_time) do
-            expect(Sidekiq::Client).to receive(:push).with(
+            expect(Sidekiq::Client).to receive(:push).with({
               'class' => SomeWorker,
               'queue' => 'high',
               'args' => ['/tmp', { 'scheduled_at' => schedule_time.to_f }]
-            )
+            })
 
             subject
           end
@@ -200,11 +202,11 @@ describe SidekiqScheduler::Scheduler do
       context 'when arguments are already expanded' do
         it 'pushes the job with the metadata as the last argument' do
           Timecop.freeze(schedule_time) do
-            expect(Sidekiq::Client).to receive(:push).with(
+            expect(Sidekiq::Client).to receive(:push).with({
               'class' => SomeWorker,
               'queue' => 'high',
               'args' => ['/tmp', { 'scheduled_at' => schedule_time.to_f }]
-            )
+            })
 
             subject
           end
@@ -234,11 +236,11 @@ describe SidekiqScheduler::Scheduler do
 
         it 'pushes the job with the metadata as the last argument' do
           Timecop.freeze(schedule_time) do
-            expect(Sidekiq::Client).to receive(:push).with(
+            expect(Sidekiq::Client).to receive(:push).with({
               'class' => SomeWorker,
               'queue' => 'high',
               'args' => [{ dir: '/tmp' }, { 'scheduled_at' => schedule_time.to_f }]
-            )
+            })
 
             subject
           end
@@ -250,11 +252,11 @@ describe SidekiqScheduler::Scheduler do
 
         it 'pushes the job with the metadata as the only argument' do
           Timecop.freeze(schedule_time) do
-            expect(Sidekiq::Client).to receive(:push).with(
+            expect(Sidekiq::Client).to receive(:push).with({
               'class' => SomeWorker,
               'queue' => 'high',
               'args' => [{ 'scheduled_at' => schedule_time.to_f }]
-            )
+            })
 
             subject
           end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -132,13 +132,11 @@ describe SidekiqScheduler::Scheduler do
 
     context 'when it is a sidekiq worker' do
       it 'prepares the parameters' do
-        expect(Sidekiq::Client).to receive(:push).with(
-          {
-            'class' => SomeWorker,
-            'queue' => 'high',
-            'args' => ['/tmp']
-          }
-        )
+        expect(Sidekiq::Client).to receive(:push).with({
+          'class' => SomeWorker,
+          'queue' => 'high',
+          'args' => ['/tmp']
+        })
 
         subject
       end


### PR DESCRIPTION
Based on the discussion we had here https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/410

I also fixed some broken specs for Ruby 3/3.1 that were expecting keyword arguments while they actually should expect a hash, which is what we push to sidekiq [here](https://github.com/sidekiq-scheduler/sidekiq-scheduler/blob/master/lib/sidekiq-scheduler/utils.rb#L86).