### PR TITLE
Drop explicit redis dependency

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -1,5 +1,3 @@
-require 'redis'
-
 require 'sidekiq-scheduler/schedule'
 require 'sidekiq-scheduler/scheduler'
 

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'redis', '>= 4.2.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
Sidekiq 7.0 depends on redis-client by default, and earlier versions depend on redis.
