### PR TITLE
Replace calls to .present?

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -35,7 +35,9 @@ module SidekiqScheduler
       config.enabled = enabled unless enabled.nil?
       config.dynamic = dynamic unless dynamic.nil?
       config.dynamic_every = dynamic_every unless dynamic_every.nil?
-      config.schedule = Sidekiq.schedule if Sidekiq.schedule.present?
+      unless Sidekiq.schedule.nil? || (Sidekiq.schedule.respond_to?(:empty?) && Sidekiq.schedule.empty?)
+        config.schedule = Sidekiq.schedule
+      end
       config.listened_queues_only = listened_queues_only unless listened_queues_only.nil?
     end
   end

--- a/lib/sidekiq-scheduler/sidekiq_adapter.rb
+++ b/lib/sidekiq-scheduler/sidekiq_adapter.rb
@@ -55,10 +55,10 @@ module SidekiqScheduler
 
     def self.sidekiq_queues(sidekiq_config)
       if SIDEKIQ_GTE_7_0_0
-        if sidekiq_config.present?
-          sidekiq_config.queues.map(&:to_s)
-        else
+        if sidekiq_config.nil? || (sidekiq_config.respond_to?(:empty?) && sidekiq_config.empty?)
           Sidekiq.instance_variable_get(:@config).queues.map(&:to_s)
+        else
+          sidekiq_config.queues.map(&:to_s)
         end
       elsif SIDEKIQ_GTE_6_5_0
         Sidekiq[:queues].map(&:to_s)


### PR DESCRIPTION
Fixes #424

I noticed two instances of `.present?` in 5.0.0 as compared to 4.0.3, and they were preventing me from using 5.0.0 in my non-Rails app. I've changed them back to base Ruby