### PR TITLE
Fix "uppercase character in header name: Cache-Control"

### DIFF
--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -10,5 +10,5 @@ if Sidekiq::VERSION >= '6.0.0'
   Sidekiq::Web.use Rack::Static, urls: ['/stylesheets-scheduler'],
                                  root: ASSETS_PATH,
                                  cascade: true,
-                                 header_rules: [[:all, { 'Cache-Control' => 'public, max-age=86400' }]]
+                                 header_rules: [[:all, { 'cache-control' => 'public, max-age=86400' }]]
 end


### PR DESCRIPTION
Using rack < 3.0.0 requires all response header keys to be lowercase: https://github.com/rack/rack/commit/472e12f5b6505cc2fdd3b5e529b616b3a2d5fbf8

fixes #431 