### PR TITLE
Don't use depicated Redis commands

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -106,7 +106,7 @@ module SidekiqScheduler
     #
     # @return [Array] array with all the changed job names
     def self.get_schedule_changes(from, to)
-      Sidekiq.redis { |r| r.zrangebyscore(schedules_changed_key, from, "(#{to}") }
+      SidekiqScheduler::SidekiqAdapter.redis_zrangebyscore(schedules_changed_key, from, "(#{to}")
     end
 
     # Register a schedule change for a given job

--- a/lib/sidekiq-scheduler/sidekiq_adapter.rb
+++ b/lib/sidekiq-scheduler/sidekiq_adapter.rb
@@ -76,5 +76,15 @@ module SidekiqScheduler
         end
       end
     end
+
+    def self.redis_zrangebyscore(key, from, to)
+      Sidekiq.redis do |r|
+        if SIDEKIQ_GTE_7_0_0
+          r.zrange(key, from, to, "BYSCORE")
+        else
+          r.zrangebyscore(key, from, to)
+        end
+      end
+    end
   end
 end

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -50,7 +50,7 @@ module SidekiqScheduler
     end
 
     def self.zrangebyscore(zset_key, from, to)
-      Sidekiq.redis { |r| r.zrangebyscore(zset_key, from, to) }
+      SidekiqScheduler::SidekiqAdapter.redis_zrangebyscore(zset_key, from, to)
     end
 
     def self.zrange(zset_key, from, to)


### PR DESCRIPTION
Closes #436 

Sidekiq 7.1 now warns on deprecated Redis commands. `zrangebyscore` is currently used by the gem which is depicated in Redis 6.2 which is the minimum required Redis version for current Sidekiq.

Since we most likely are supporting the latest 7.x of Sidekiq, I reused the "GTE 7.0" check and redirected calls to `zrangebyscore` to use the Sidekiq Adaptor class.

The difference in commands is based off of the changes to Sidekiq when it swapped out the depricated call: https://github.com/sidekiq/sidekiq/commit/1aca434e5cd830cbd0020f1f82ef3a3cb6b2d477#diff-25f829140be25a886134933b537d356dddb12234ca85319e50b381f9edb6b74dR686