### PR TITLE
Reset `SidekiqScheduler::Scheduler.dynamic` after spec

### DIFF
--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -7,7 +7,11 @@ describe SidekiqScheduler::Schedule do
     let(:job_id) { 'super_job' }
     let(:schedule) { ScheduleFaker.default_options }
 
-    before { SidekiqScheduler::Scheduler.dynamic = true }
+    before do
+      @original_dynamic, SidekiqScheduler::Scheduler.dynamic = SidekiqScheduler::Scheduler.dynamic, true
+    end
+
+    after { SidekiqScheduler::Scheduler.dynamic = @original_dynamic }
 
     it 'sets the schedule on redis' do
       subject


### PR DESCRIPTION
Currently, `./spec/sidekiq-scheduler/scheduler_initialize_spec.rb` will fail if runs after `spec/sidekiq-scheduler/schedule_spec.rb`

```bash
$ bundle exec rspec --seed 28447 --fail-fast
