### PR TITLE
Change cache-control to private

### DIFF
--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -9,4 +9,4 @@ Sidekiq::Web.locales << File.expand_path("#{File.dirname(__FILE__)}/../../../web
 Sidekiq::Web.use Rack::Static, urls: ['/stylesheets-scheduler'],
                                root: ASSETS_PATH,
                                cascade: true,
-                               header_rules: [[:all, { 'cache-control' => 'public, max-age=86400' }]]
+                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]


### PR DESCRIPTION
As mentioned in https://github.com/sidekiq/sidekiq/issues/5936 the public cache control could leak information when used with CloudFront or other CDNs. It was decided to change the cache setting in Sidekiq web's static assets to private.

This changes the gem's cache-control settings to match the recently released Sidekiq's.