### PR TITLE
Add note about Sidekiq::Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ class HelloWorld
 end
 ```
 
+__Note:__ In Sidekiq v6.3 `Sidekiq::Job` was introduced as an alias for `Sidekiq::Worker`. `Sidekiq::Worker` has been officially deprecated in Sidekiq v7 although it still exists for backwards compatibility. It is therefore recommended to use `include Sidekiq::Job` in the above example unless an older version of Sidekiq is required.
+
 ``` yaml
 # config/sidekiq.yml
 


### PR DESCRIPTION
Sidekiq::Worker has been renamed as Sidekiq::Job. See;

* Sidekiq::Job added as an alias in v6.3: https://github.com/sidekiq/sidekiq/blob/main/Changes.md#630
* Sidekiq::Worker replaced with Sidekiq::Job and Sidekiq::Worker retained as an alias in v6.4: https://github.com/sidekiq/sidekiq/blob/main/Changes.md#640

This PR adds a note to the README file to reflect this. The example still uses the old, deprecated version as this will reliably work with all supported versions of Sidekiq.

Fixes #456 