### PR TITLE
Update tilt dependency (or at least increase compatibility)

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sidekiq', '>= 6', '< 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
-  s.add_dependency 'tilt', '>= 1.4.0'
+  s.add_dependency 'tilt', '>= 1.4.0', '< 3'
 
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
Hi team. Thanks for this fantastic work!

I will adopt this gem in an internal project here at meilisearch, but we use tilt internally in a newer version. 
Since I ran the test suite with the new version and it didn't break anything, I guess it wouldn't hurt to increase the compatibility range in the scheduler.

So this PR increases the compatibility range to accept any tilt version less than 3.