### PR TITLE
Fix broken CI against Sidekiq 7.2

### DIFF
--- a/spec/support/initialization/redis.rb
+++ b/spec/support/initialization/redis.rb
@@ -2,6 +2,10 @@ require 'sidekiq/redis_connection'
 
 RSpec.configure do |config|
   config.before do
-    Sidekiq.redis { |r| r.flushdb(async: true) }
+    if Sidekiq::VERSION >= '7.2'
+      Sidekiq.redis { |r| r.flushdb('async') }
+    else
+      Sidekiq.redis { |r| r.flushdb(async: true) }
+    end
   end
 end


### PR DESCRIPTION
The API of Redis commands via Sidekiq was changed at Sidekiq 7.2. This PR fixes to use the new style.

Ref: https://github.com/sidekiq/sidekiq/issues/6083、 https://github.com/sidekiq/sidekiq/commit/3b8a3c3ea29b63b21e01010f630c936d25265712