### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         redis-version: ["~> 4.2", "~> 5"]
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
         sidekiq-version: ['~> 6', '~> 7']
     services:
       redis:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with: 
+        with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Run tests


### PR DESCRIPTION
This PR just adds Ruby 3.3 to the CI matrix.