### PR TITLE
Use Redis MULTI command

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -130,9 +130,9 @@ module SidekiqScheduler
     def self.register_job_instance(job_name, time)
       job_key = pushed_job_key(job_name)
       registered, _ = Sidekiq.redis do |r|
-        r.pipelined do |pipeline|
-          pipeline.zadd(job_key, time.to_i, time.to_i)
-          pipeline.expire(job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
+        r.multi do |m|
+          m.zadd(job_key, time.to_i, time.to_i)
+          m.expire(job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
         end
       end
 


### PR DESCRIPTION
This is another change that I think helped eliminate the multi job issue in addition to #463.

From the Redis [docs](https://redis.io/docs/interact/transactions/)
> All the commands in a transaction are serialized and executed sequentially. A request sent by another client will never be served in the middle of the execution of a Redis Transaction. This guarantees that the commands are executed as a single isolated operation.

The `multi` block form also pipelines the commands so this is just making the command a transaction.