### PR TITLE
undefined method `next_time' for nil:NilClass (#445)

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -128,6 +128,8 @@ module SidekiqScheduler
             schedule, options = SidekiqScheduler::RufusUtils.normalize_schedule_options(config_interval_type)
 
             rufus_job = new_job(name, interval_type, config, schedule, options)
+            return unless rufus_job
+
             @scheduled_jobs[name] = rufus_job
             SidekiqScheduler::Utils.update_job_next_time(name, rufus_job.next_time)
 

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -698,18 +698,38 @@ describe SidekiqScheduler::Scheduler do
     end
 
     context 'at schedule' do
-      let(:config) { ScheduleFaker.at_schedule(at: Time.now + 60) }
+      let(:config) { ScheduleFaker.at_schedule(at: at) }
 
-      it 'adds the job to rufus scheduler' do
-        expect(instance.rufus_scheduler.jobs.size).to eq(1)
+      context 'in the future' do
+        let(:at) { Time.now + 60 }
+
+        it 'adds the job to rufus scheduler' do
+          expect(instance.rufus_scheduler.jobs.size).to eq(1)
+        end
+
+        it 'puts the job inside the scheduled hash' do
+          expect(instance.scheduled_jobs.keys).to eq([job_name])
+        end
+
+        it 'stores the next time execution correctly' do
+          expect(next_time_execution).to be
+        end
       end
 
-      it 'puts the job inside the scheduled hash' do
-        expect(instance.scheduled_jobs.keys).to eq([job_name])
-      end
+      context 'in the past' do
+        let(:at) { Time.now - 60 }
 
-      it 'stores the next time execution correctly' do
-        expect(next_time_execution).to be
+        it 'does not add the job to rufus scheduler' do
+          expect(instance.rufus_scheduler.jobs).to be_empty
+        end
+
+        it 'does not put the job inside the scheduled hash' do
+          expect(instance.scheduled_jobs.keys).not_to include(job_name)
+        end
+
+        it 'stores the next time execution correctly' do
+          expect(next_time_execution).not_to be
+        end
       end
     end
 


### PR DESCRIPTION
Sidekiq-scheduler allows to schedule jobs using different schedule types. One of the schedule types is `at`, that pushes jobs only once and schedules it in a single point in time. Defining a job in `sidekiq.yml` with an `at` schedule type and a date in the past resulted in an error and prevented Sidekiq from starting:

```
11:36:07 sidekiq.1 | 2024-05-01T09:36:07.190Z pid=515927 tid=axvj INFO: Scheduling foo {"class"=>"FooJob", "at"=>"2024/04/30", "enabled"=>false, "queue"=>"default"}
11:36:07 sidekiq.1 | 2024-05-01T09:36:07.191Z pid=515927 tid=axvj WARN: {"context":"Exception during Sidekiq lifecycle event.","event":"startup"}
11:36:07 sidekiq.1 | 2024-05-01T09:36:07.191Z pid=515927 tid=axvj WARN: NoMethodError: undefined method `next_time' for nil
11:36:07 sidekiq.1 | 2024-05-01T09:36:07.191Z pid=515927 tid=axvj WARN: 
11:36:07 sidekiq.1 | undefined method `next_time' for nil
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:133:in `block in load_schedule_job'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:123:in `each'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:123:in `load_schedule_job'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:101:in `block in load_schedule!'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:99:in `each'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/scheduler.rb:99:in `load_schedule!'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/manager.rb:24:in `start'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler/sidekiq_adapter.rb:41:in `start_schedule_manager'
11:36:07 sidekiq.1 | /home/maurice/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sidekiq-scheduler-5.0.3/lib/sidekiq-scheduler.rb:21:in `block (2 levels) in <main>'
```

When the date of an `at` scheduled job is in the past, it does not have to schedule the job another time. This PR fixes this by skipping to set the job next_time.