### PR TITLE
Don't clear "schedule" key on boot in dynamic schedule mode

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -13,7 +13,7 @@ module SidekiqScheduler
 
       @scheduler_instance = SidekiqScheduler::Scheduler.new(config)
       SidekiqScheduler::Scheduler.instance = @scheduler_instance
-      Sidekiq.schedule = config.schedule if @scheduler_instance.enabled
+      Sidekiq.schedule = config.schedule if @scheduler_instance.enabled && !@scheduler_instance.dynamic
     end
 
     def stop

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -55,6 +55,18 @@ describe SidekiqScheduler::Manager do
           expect(subject.listened_queues_only).to eql(scheduler_options[:scheduler][:listened_queues_only])
         }
       end
+
+      context 'when dynamic option is true' do
+        subject do
+          scheduler_options[:scheduler][:dynamic] = true
+          described_class.new(scheduler_config)
+          SidekiqScheduler::Scheduler.instance
+        end
+
+        it {
+          expect { subject }.not_to change { Sidekiq.schedule }
+        }
+      end
     end
 
     context 'when enabled option is false' do


### PR DESCRIPTION
There have been a number of issues around dynamic jobs on boot (e.g. #188, #227, #284, #125), which I think all have a common root cause.

During Manager#initialize, the schedule is loaded, even if that schedule is empty, and even in dynamic mode. See https://github.com/sidekiq-scheduler/sidekiq-scheduler/blob/9da5f130072ae8bf8f500862f44789029234b84e/lib/sidekiq-scheduler/manager.rb#L16

This causes the `schedule` key to be removed from Redis as it's now empty, so when we get to https://github.com/sidekiq-scheduler/sidekiq-scheduler/blob/9da5f130072ae8bf8f500862f44789029234b84e/lib/sidekiq-scheduler/scheduler.rb#L85, the schedule cannot be loaded as it's already gone.

This PR simply disables that initial setting of the schedule in dynamic mode.

Obviously this might affect existing running systems... not sure what to do about that.