### PR TITLE
Implement `to_hash` method in Manager, Scheduler and Config classes.

### DIFF
--- a/lib/sidekiq-scheduler/config.rb
+++ b/lib/sidekiq-scheduler/config.rb
@@ -59,6 +59,17 @@ module SidekiqScheduler
       SidekiqScheduler::SidekiqAdapter.sidekiq_queues(sidekiq_config)
     end
 
+    def to_hash
+      {
+        enabled: enabled?,
+        dynamic: dynamic?,
+        dynamic_every: dynamic_every?,
+        shedule: schedule,
+        listened_queues_only: listened_queues_only?,
+        rufus_scheduler_options: rufus_scheduler_options
+      }
+    end
+
     private
 
     attr_reader :scheduler_config

--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -24,6 +24,15 @@ module SidekiqScheduler
       @scheduler_instance.load_schedule!
     end
 
+    # This method is needed to avoid exposing unnecessary information.
+    # Because ActiveSupport's `as_json` traverses instance values to convert the object to a hash
+    # unless it responds to `to_hash`.
+    def to_hash
+      {
+        scheduler: @scheduler_instance.to_hash
+      }
+    end
+
     private
 
     def set_current_scheduler_options(config)

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -250,6 +250,12 @@ module SidekiqScheduler
       end
     end
 
+    def to_hash
+      {
+        scheduler_config: @scheduler_config.to_hash
+      }
+    end
+
     private
 
     attr_reader :scheduler_config

--- a/spec/sidekiq-scheduler/config_spec.rb
+++ b/spec/sidekiq-scheduler/config_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe SidekiqScheduler::Config do
+  let(:config) { described_class.new(sidekiq_config: sidekiq_config) }
+  let(:sidekiq_config) { SConfigWrapper.new.reset!(input_config) }
+  let(:input_config) { {} }
+
+  describe '#to_hash' do
+    subject { config.to_hash }
+
+    it 'returns a hash of the config' do
+      expect(subject).to eq(
+        {
+          enabled: true,
+          dynamic: false,
+          dynamic_every: '5s',
+          shedule: {},
+          listened_queues_only: nil,
+          rufus_scheduler_options: {}
+        }
+      )
+    end
+  end
+end

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -241,4 +241,36 @@ describe SidekiqScheduler::Manager do
       subject
     end
   end
+
+  describe '#to_hash' do
+    subject { manager.to_hash }
+
+    let(:manager) do
+      described_class.new(
+        SidekiqScheduler::Config.new(
+          sidekiq_config: sidekiq_config_for_options(
+            {
+              scheduler: {
+                enabled: true,
+                dynamic: true,
+                dynamic_every: '5s',
+                listened_queues_only: true,
+                schedule: { 'current' => ScheduleFaker.cron_schedule('queue' => 'default') }
+              },
+            }
+          )
+        )
+      )
+    end
+
+    let(:scheduler_instance) { manager.instance_variable_get(:@scheduler_instance) }
+
+    it 'returns a hash including a result of the scheduler_instance.to_hash' do
+      expect(subject).to eq(
+        {
+          scheduler: scheduler_instance.to_hash
+        }
+      )
+    end
+  end
 end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -1070,4 +1070,16 @@ describe SidekiqScheduler::Scheduler do
       end
     end
   end
+
+  describe '#to_hash' do
+    subject { instance.to_hash }
+
+    it 'returns a hash including a result of the scheduler_config.to_hash' do
+      expect(subject).to eq(
+        {
+          scheduler_config: scheduler_config.to_hash
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
ref #468 

## What I did

- add `to_hash` method to `SidekiqScheduler::Manager`, `SidekiqScheduler::Scheduler` and `SidekiqScheduler::Config` classes.
- create `spec/sidekiq-scheduler/config_spec.rb` to test.
- add test in `spec/sidekiq-scheduler/scheduler_spec.rb` and `spec_sidekiq-scheduler/manager_spec.rb`.

Here is an example output of `SidekiqScheduler::Manager#to_hash`.
```ruby
{
  "scheduler" => {
    "scheduler_config" => {
      "enabled" => true, 
      "dynamic" => true, 
      "dynamic_every" => "5s", 
      "shedule" => {
        "current" => {
          "cron" => "* * * * *", 
          "class" => "SomeWorker", 
          "args" => "some_arg", 
          "queue" => "default"
        }
      }, 
      "listened_queues_only" => true, 
      "rufus_scheduler_options" => {}
    }
  }
}
```

All spec are passed in my local.

Unfortunately, this doesn't affect `inspect` behavior. We need more improvement to solve #462