### PR TITLE
Use new web ui registration and stylesheet helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         redis-version: ["~> 4.2", "~> 5"]
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3']
         sidekiq-version: ['~> 6', '~> 7']
     services:
       redis:

--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -1,12 +1,27 @@
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 
-ASSETS_PATH = File.expand_path('../../../web/assets', __dir__)
+if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_3_0
 
-Sidekiq::Web.register(SidekiqScheduler::Web)
-Sidekiq::Web.tabs['recurring_jobs'] = 'recurring-jobs'
-Sidekiq::Web.locales << File.expand_path("#{File.dirname(__FILE__)}/../../../web/locales")
+  # Locale and asset cache is configured in `.regiester`
+  Sidekiq::Web.register(SidekiqScheduler::Web,
+    name: "recurring_jobs",
+    tab: ["Recurring Jobs"],
+    index: ["recurring-jobs"],
+    root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
+    asset_paths: ["stylesheets-scheduler"]) do |app|
+    # add middleware or additional settings here
+  end
 
-Sidekiq::Web.use Rack::Static, urls: ['/stylesheets-scheduler'],
-                               root: ASSETS_PATH,
-                               cascade: true,
-                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+else
+
+  ASSETS_PATH = File.expand_path('../../../web/assets', __dir__)
+
+  Sidekiq::Web.register(SidekiqScheduler::Web)
+  Sidekiq::Web.tabs['recurring_jobs'] = 'recurring-jobs'
+  Sidekiq::Web.locales << File.expand_path("#{File.dirname(__FILE__)}/../../../web/locales")
+
+  Sidekiq::Web.use Rack::Static, urls: ['/stylesheets-scheduler'],
+                                 root: ASSETS_PATH,
+                                 cascade: true,
+                                 header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+end

--- a/lib/sidekiq-scheduler/sidekiq_adapter.rb
+++ b/lib/sidekiq-scheduler/sidekiq_adapter.rb
@@ -4,6 +4,7 @@ module SidekiqScheduler
   class SidekiqAdapter
     SIDEKIQ_GTE_6_5_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
     SIDEKIQ_GTE_7_0_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
+    SIDEKIQ_GTE_7_3_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.3.0')
 
     def self.fetch_scheduler_config_from_sidekiq(sidekiq_config)
       return {} if sidekiq_config.nil?

--- a/web/locales/cs.yml
+++ b/web/locales/cs.yml
@@ -1,4 +1,5 @@
 cs:
+  "Recurring Jobs": Pravidelně opakované
   recurring_jobs: Pravidelně opakované
   name: Jméno
   description: Popis

--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -1,4 +1,5 @@
 de:
+  "Recurring Jobs": Wiederkehrende Jobs
   recurring_jobs: Wiederkehrende Jobs
   name: Name
   description: Beschreibung

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  "Recurring Jobs": Recurring Jobs
   recurring_jobs: Recurring Jobs
   name: Name
   description: Description

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -1,4 +1,5 @@
 es:
+  "Recurring Jobs": Tareas Recurrentes
   recurring_jobs: Tareas Recurrentes
   name: Nombre
   description: Descripción

--- a/web/locales/fr.yml
+++ b/web/locales/fr.yml
@@ -1,4 +1,5 @@
 fr:
+  "Recurring Jobs": Tâches récurrentes
   recurring_jobs: Tâches récurrentes
   name: Nom
   description: Description

--- a/web/locales/gd.yml
+++ b/web/locales/gd.yml
@@ -1,4 +1,5 @@
 ﻿gd:
+  "Recurring Jobs": Obraichean ath-chùrsach
   recurring_jobs: Obraichean ath-chùrsach
   name: Ainm
   description: Tuairisgeul

--- a/web/locales/it.yml
+++ b/web/locales/it.yml
@@ -1,4 +1,5 @@
 it:
+  "Recurring Jobs": Job ricorrenti
   recurring_jobs: Job ricorrenti
   name: Nome
   description: Descrizione

--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
+  "Recurring Jobs": 定期ジョブ
   recurring_jobs: 定期ジョブ
   name: 名前
   description: 説明

--- a/web/locales/nl.yml
+++ b/web/locales/nl.yml
@@ -1,4 +1,5 @@
 nl:
+  "Recurring Jobs": Herhalende taken
   recurring_jobs: Herhalende taken
   name: Naam
   description: Beschrijving

--- a/web/locales/pl.yml
+++ b/web/locales/pl.yml
@@ -1,4 +1,5 @@
 pl:
+  "Recurring Jobs": Okresowe
   recurring_jobs: Okresowe
   name: Nazwa
   description: Opis

--- a/web/locales/pt-BR.yml
+++ b/web/locales/pt-BR.yml
@@ -1,4 +1,5 @@
 pt-BR:
+  "Recurring Jobs": Jobs Recorrentes
   recurring_jobs: Jobs Recorrentes
   name: Nome
   description: Descrição
@@ -6,7 +7,7 @@ pt-BR:
   class: Classe
   queue: Fila
   arguments: Argumentos
-  enqueue_now: Enfileirar agora 
+  enqueue_now: Enfileirar agora
   last_time: Última execução
   next_time: Próxima execução
   no_next_time: Não há mais execuçoẽs

--- a/web/locales/ru.yml
+++ b/web/locales/ru.yml
@@ -1,4 +1,5 @@
 ru:
+  "Recurring Jobs": Расписание задач
   recurring_jobs: Расписание задач
   name: Название
   description: Описание

--- a/web/locales/sv.yml
+++ b/web/locales/sv.yml
@@ -1,4 +1,5 @@
 sv:
+  "Recurring Jobs": Återkommande jobb
   recurring_jobs: Återkommande jobb
   name: Namn
   description: Beskrivning

--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -1,4 +1,5 @@
 zh-cn:
+  "Recurring Jobs": 周期作业
   recurring_jobs: 周期作业
   name: 名称
   description: 描述

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -1,4 +1,8 @@
+<% if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_3_0 %>
+<%= style_tag "stylesheets-scheduler/recurring_jobs.css" %>
+<% else %>
 <link href="<%= root_path %>stylesheets-scheduler/recurring_jobs.css" media="screen" rel="stylesheet" type="text/css" />
+<% end %>
 
 <div class="row">
   <div class="col-sm-6">


### PR DESCRIPTION
Sidekiq 7.3.0 and later added changes to how the web UI for plugins work.

- The registration has a first-class API to register a plugin.
  - See: https://github.com/sidekiq/sidekiq/blob/main/examples/webui-ext/lib/sidekiq-redis_info/web.rb#L20
  - The old registration path is still allowed, but will be removed in Sidekiq 8.0.
- New stylesheet and script helpers were added to allow linking to scripts and stylesheets for the plugin. They add nonce attributes to protect against XSS attacks.
  - See: https://github.com/sidekiq/sidekiq/blob/main/examples/webui-ext/readme.md
  - Sidekiq 8.0 and later will require nouce attributes for all of Sidekiq web.

To make this gem forwards compatible with 8.0...

- Added a new constant to check for Sidekiq 7.3 and later.
- For current and future Sidekiq releases, we'll use the new `style_tag` helper to output the `<link>` tag. Older Sidekiq versions will continue to use the hand-crafted tag as it stands today.
- For current and future Sidekiq releases, we'll use the newer registration API for the web UI.