### PR TITLE
Fix typos in non-production code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
  
 # 5.0.0
 
-  - [**FIX**] Ensure generated scheduled time has a precision of 3 miliseconds. [#418](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/418)
+  - [**FIX**] Ensure generated scheduled time has a precision of 3 milliseconds. [#418](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/418)
 
 *Note 1:* Check [# 5.0.0.beta1](#500beta1) & [# 5.0.0.beta2](#500beta2) releases for breaking changes.
 
@@ -91,6 +91,6 @@
 - [**ENHANCEMENT**] Highlight disabled jobs [#369](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/369)
 - [**BREAKING CHANGE**] Require redis 4.2.0 [#370](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/370)
 - [**FIX**] Fixes redis deprecation warning regarding `exists` [#370](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/370)
-- [**BREAKING CHANGE**] Remove dependecy on thwait and e2mmap [#371](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/371)
+- [**BREAKING CHANGE**] Remove dependency on thwait and e2mmap [#371](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/371)
 - Support Ruby 3.1 [#373](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/373)
 - [**BREAKING CHANGE**] Set rufus_scheduler_options via sidekiq.yml file as configuration option [#375](https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/375)

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ You can also override the thread pool size in Rufus Scheduler by setting the fol
 ## Notes about running on Multiple Hosts
 
 Under normal conditions, `cron` and `at` jobs are pushed once regardless of the number of `sidekiq-scheduler` running instances,
-assumming that time deltas between hosts is less than 24 hours.
+assuming that time deltas between hosts is less than 24 hours.
 
 Non-normal conditions that could push a specific job multiple times are:
  - high cpu load + a high number of jobs scheduled at the same time, like 100 jobs
@@ -494,7 +494,7 @@ end
 
 ## The Spring preloader and Testing your initializer via Rails console
 
-If you're pulling in your schedule from a YML file via an initializer as shown, be aware that the Spring application preloader included with Rails will interefere with testing via the Rails console.
+If you're pulling in your schedule from a YML file via an initializer as shown, be aware that the Spring application preloader included with Rails will interfere with testing via the Rails console.
 
 **Spring will not reload initializers** unless the initializer is changed.  Therefore, if you're making a change to your YML schedule file and reloading Rails console to see the change, Spring will make it seem like your modified schedule is not being reloaded.
 

--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -65,7 +65,7 @@ module SidekiqScheduler
     end
     alias_method :schedule!, :reload_schedule!
 
-    # Retrive the schedule configuration for the given name
+    # Retrieve the schedule configuration for the given name
     # if the name is nil it returns a hash with all the
     # names end their schedules.
     def get_schedule(name = nil)

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -17,7 +17,7 @@ module SidekiqScheduler
     # saying we will have to do it somehow still)
     #
     # NOTE: ^ Keeping this TODO here for now, in a future version of this project
-    # we will remove those attr acessors and use only our config object. For now,
+    # we will remove those attr accessors and use only our config object. For now,
     # let's keep as it is.
 
     # Set to enable or disable the scheduler.
@@ -308,7 +308,7 @@ module SidekiqScheduler
     #
     # @example with hash argument
     #   arguments_with_metadata({value: 1}, scheduled_at: Time.now.round(3))
-    #   #=> [{value: 1}, {scheduled_at: <miliseconds since epoch>}]
+    #   #=> [{value: 1}, {scheduled_at: <milliseconds since epoch>}]
     #
     # @param args [Array|Hash]
     # @param metadata [Hash]

--- a/lib/sidekiq-scheduler/utils.rb
+++ b/lib/sidekiq-scheduler/utils.rb
@@ -73,7 +73,7 @@ module SidekiqScheduler
     # Returns true if the enqueuing needs to be done for an ActiveJob
     #  class false otherwise.
     #
-    # @param [Class] klass the class to check is decendant from ActiveJob
+    # @param [Class] klass the class to check is descendant from ActiveJob
     #
     # @return [Boolean]
     def self.active_job_enqueue?(klass)


### PR DESCRIPTION
```
codespell **/*.rb **/*.md -w -L shedule
```