### PR TITLE
[POTENTIAL BREAKING CHANGE] Fix typo in `config#to_hash`

### DIFF
--- a/lib/sidekiq-scheduler/config.rb
+++ b/lib/sidekiq-scheduler/config.rb
@@ -64,7 +64,7 @@ module SidekiqScheduler
         enabled: enabled?,
         dynamic: dynamic?,
         dynamic_every: dynamic_every?,
-        shedule: schedule,
+        schedule: schedule,
         listened_queues_only: listened_queues_only?,
         rufus_scheduler_options: rufus_scheduler_options
       }

--- a/spec/sidekiq-scheduler/config_spec.rb
+++ b/spec/sidekiq-scheduler/config_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SidekiqScheduler::Config do
           enabled: true,
           dynamic: false,
           dynamic_every: '5s',
-          shedule: {},
+          schedule: {},
           listened_queues_only: nil,
           rufus_scheduler_options: {}
         }


### PR DESCRIPTION
Hello, is this done on purpose?

Since this is a potential breaking change, I can preserve `shedule`, and that should be deprecated and removed in 6.0

---

Potential breaking change

Ref: #470