### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
+  s.metadata = { 'rubygems_mfa_required' => 'true' }
+
   s.add_dependency 'sidekiq', '>= 6', '< 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0', '< 3'


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/

---

Hello,

even if the numbers of downloads can implicitly require MFA to publish this gem, adding this metadata will add an explicit panel on the right sidebar of the gem.

This is also in Sidekiq and a lot of popular gems (which already require MFA)

Ref: sidekiq/sidekiq#5850

![image](https://github.com/sidekiq-scheduler/sidekiq-scheduler/assets/556268/09c9693e-b870-4e41-84f4-aee199f41d5e)

