### PR TITLE
Only call SidekiqScheduler::Utils.calc_cron_run_time when it seems really necessary.

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -267,7 +267,9 @@ module SidekiqScheduler
         if job_enabled?(name)
           conf = SidekiqScheduler::Utils.sanitize_job_config(config)
 
-          if job.is_a?(Rufus::Scheduler::CronJob)
+          # `SidekiqScheduler::Utils.calc_cron_run_time` only works with a job running periodically.
+          # Also, `SidekiqScheduler::Utils.calc_cron_run_time` is only required jobs are execute frequently. So only call it if really needed.
+          if job.is_a?(Rufus::Scheduler::CronJob) && job.cron_line.rough_frequency <= 60
             idempotent_job_enqueue(name, SidekiqScheduler::Utils.calc_cron_run_time(job.cron_line, time.utc), conf)
           else
             idempotent_job_enqueue(name, time, conf)


### PR DESCRIPTION
As I described #482,  `SidekiqScheduler::Utils.calc_cron_run_time` only works with a job running periodically.
Also, `SidekiqScheduler::Utils.calc_cron_run_time` is only required jobs are execute frequently I think. So this PR changes to call it when it really needed.

Also, I added the test for `#load_schedule_job` when the cron is not periodically to prevent regression.