### PR TITLE
Correctly clear scheduled jobs with `Scheduler#clear_schedule!`

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -196,7 +196,7 @@ module SidekiqScheduler
         @rufus_scheduler = nil
       end
 
-      @@scheduled_jobs = {}
+      @scheduled_jobs = {}
 
       rufus_scheduler
     end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -299,6 +299,16 @@ describe SidekiqScheduler::Scheduler do
 
       instance.clear_schedule!(stop_option)
     end
+
+    it 'clears scheduled jobs' do
+      Sidekiq.schedule = { 'some_job '=> ScheduleFaker.every_schedule }
+      instance.load_schedule_job('some_job', ScheduleFaker.every_schedule )
+
+      expect do
+        instance.clear_schedule!
+      end.to change { instance.scheduled_jobs }
+      expect(instance.scheduled_jobs).to be_empty
+    end
   end
 
   describe '#load_schedule!' do


### PR DESCRIPTION
The scheduled jobs have changed to instance variable by 9f90f5c.