### PR TITLE
Fix scheduling for aperiodic cron jobs

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -267,10 +267,8 @@ module SidekiqScheduler
         if job_enabled?(name)
           conf = SidekiqScheduler::Utils.sanitize_job_config(config)
 
-          # `SidekiqScheduler::Utils.calc_cron_run_time` only works with a job running periodically.
-          # Also, `SidekiqScheduler::Utils.calc_cron_run_time` is only required jobs are execute frequently. So only call it if really needed.
-          if job.is_a?(Rufus::Scheduler::CronJob) && job.cron_line.rough_frequency <= 60
-            idempotent_job_enqueue(name, SidekiqScheduler::Utils.calc_cron_run_time(job.cron_line, time.utc), conf)
+          if job.is_a?(Rufus::Scheduler::CronJob)
+            idempotent_job_enqueue(name, SidekiqScheduler::Utils.calc_cron_run_time(job.cron_line, time.to_t), conf)
           else
             idempotent_job_enqueue(name, time, conf)
           end

--- a/lib/sidekiq-scheduler/utils.rb
+++ b/lib/sidekiq-scheduler/utils.rb
@@ -155,9 +155,11 @@ module SidekiqScheduler
     #
     # @return [Time]
     def self.calc_cron_run_time(cron, time)
-      time = time.round # remove sub seconds to prevent rounding errors.
-      next_t = cron.next_time(time).utc
-      previous_t = cron.previous_time(time).utc
+      time = time.floor # remove sub seconds to prevent rounding errors.
+      return time if cron.match?(time) # If the time is a perfect match then return it.
+
+      next_t = cron.next_time(time).to_t
+      previous_t = cron.previous_time(time).to_t
       # The `time` var is some point between `previous_t` and `next_t`.
       # Figure out how far off we are from each side in seconds.
       next_diff = next_t - time


### PR DESCRIPTION
This PR should fix the issues discussed in https://github.com/sidekiq-scheduler/sidekiq-scheduler/pull/484

Thanks @y-yagi @muk-ai and @marcelolx

If anyone has opinions on the use of local time vs UTC let me know. I decided to use local because Rufus is ultimately just using `Time.now`. I'm pretty sure it doesn't really matter as long as its consistent.

- Use `Fugit::Cron#match?` to check for exact time match. 
- Use `EtOrbi::EoTime#to_t` instead of `EtOrbi::EoTime#utc` to keep everything in local time.
- Use `Time#floor` instead of `Time#round`.
- Added specs for aperiodic jobs with and without time zones. 