### PR TITLE
Remove `tilt` from the dependency

### DIFF
--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -1,5 +1,4 @@
 require 'sidekiq'
-require 'tilt/erb'
 
 require_relative 'sidekiq/scheduler'
 require_relative 'sidekiq-scheduler/version'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sidekiq', '>= 6', '< 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
-  s.add_dependency 'tilt', '>= 1.4.0', '< 3'
 
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
It seems that `tilt` is for `sinatra`.
https://github.com/sidekiq-scheduler/sidekiq-scheduler/commit/0313e5b#r14982005

I assume this was needed when the Sidekiq UI depended on `sinatra`, but that has not depended on it since
https://github.com/sidekiq/sidekiq/pull/3075.

So I think we don't need it now. Let's remove it.