### PR TITLE
Adds visualization of disabled recurring jobs to Dark Mode

### DIFF
--- a/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
+++ b/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
@@ -25,7 +25,7 @@
     border: 1px solid #555;
   }
   .list-group-item-disabled {
-    background-color: #333;
+    color: #585454;
   }
 }
 

--- a/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
+++ b/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
@@ -24,6 +24,9 @@
     color: white;
     border: 1px solid #555;
   }
+  .list-group-item-disabled {
+    background-color: #444;
+  }
 }
 
 .toggle-all-buttons {

--- a/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
+++ b/web/assets/recurring_jobs/stylesheets-scheduler/recurring_jobs.css
@@ -25,7 +25,7 @@
     border: 1px solid #555;
   }
   .list-group-item-disabled {
-    background-color: #444;
+    background-color: #333;
   }
 }
 


### PR DESCRIPTION
The current dark mode does not visually differentiate between enabled and disabled jobs.  The light mode version tints disabled jobs slightly differently.  

This patch adds this in to dark mode, which signficantly reduces the cognitive load when determining which jobs are active or disabled.

Super-simple patch, simply changes the text color of disabled jobs to a light gray instead of white.

![sidekiq-scheduler-dark-mode-update](https://github.com/user-attachments/assets/c4e35500-c861-4e7d-9149-3609dab09a22)

