### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         redis-version: ["~> 4.2", "~> 5"]
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         sidekiq-version: ['~> 6', '~> 7']
     services:
       redis:


### PR DESCRIPTION
This PR adds Ruby 3.4 to the CI matrix.