### PR TITLE
Clean up checks and logic for older Sidekiq versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         redis-version: ["~> 4.2", "~> 5"]
         ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
-        sidekiq-version: ['~> 6', '~> 7']
+        sidekiq-version: ['~> 7.3']
     services:
       redis:
         image: redis

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem "redis", ENV.fetch("REDIS_VERSION", ">= 5")
-gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
+gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 7.3")
 gemspec

--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -1,27 +1,11 @@
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 
-if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_3_0
-
-  # Locale and asset cache is configured in `.register`
-  Sidekiq::Web.register(SidekiqScheduler::Web,
-    name: "recurring_jobs",
-    tab: ["Recurring Jobs"],
-    index: ["recurring-jobs"],
-    root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
-    asset_paths: ["stylesheets-scheduler"]) do |app|
-    # add middleware or additional settings here
-  end
-
-else
-
-  ASSETS_PATH = File.expand_path('../../../web/assets', __dir__)
-
-  Sidekiq::Web.register(SidekiqScheduler::Web)
-  Sidekiq::Web.tabs['recurring_jobs'] = 'recurring-jobs'
-  Sidekiq::Web.locales << File.expand_path("#{File.dirname(__FILE__)}/../../../web/locales")
-
-  Sidekiq::Web.use Rack::Static, urls: ['/recurring_jobs/stylesheets-scheduler'],
-                                 root: ASSETS_PATH,
-                                 cascade: true,
-                                 header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+# Locale and asset cache is configured in `.register`
+Sidekiq::Web.register(SidekiqScheduler::Web,
+  name: "recurring_jobs",
+  tab: ["Recurring Jobs"],
+  index: ["recurring-jobs"],
+  root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
+  asset_paths: ["stylesheets-scheduler"]) do |app|
+  # add middleware or additional settings here
 end

--- a/lib/sidekiq-scheduler/sidekiq_adapter.rb
+++ b/lib/sidekiq-scheduler/sidekiq_adapter.rb
@@ -2,8 +2,6 @@ module SidekiqScheduler
   class OptionNotSupportedAnymore < StandardError; end
 
   class SidekiqAdapter
-    SIDEKIQ_GTE_6_5_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
-    SIDEKIQ_GTE_7_0_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
     SIDEKIQ_GTE_7_3_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.3.0')
 
     def self.fetch_scheduler_config_from_sidekiq(sidekiq_config)
@@ -11,80 +9,43 @@ module SidekiqScheduler
 
       check_using_old_sidekiq_scheduler_config!(sidekiq_config)
 
-      if SIDEKIQ_GTE_6_5_0
-        sidekiq_config.fetch(:scheduler, {})
-      else
-        sidekiq_config.options.fetch(:scheduler, {})
-      end
+      sidekiq_config.fetch(:scheduler, {})
     end
 
     def self.check_using_old_sidekiq_scheduler_config!(sidekiq_config)
       %i[enabled dynamic dynamic_every schedule listened_queues_only rufus_scheduler_options].each do |option|
-        if SIDEKIQ_GTE_7_0_0
-          if sidekiq_config.key?(option)
-            raise OptionNotSupportedAnymore, ":#{option} option should be under the :scheduler: key"
-          end
-        elsif SIDEKIQ_GTE_6_5_0
-          unless sidekiq_config[option].nil?
-            raise OptionNotSupportedAnymore, ":#{option} option should be under the :scheduler: key"
-          end
-        else
-          if sidekiq_config.options.key?(option)
-            raise OptionNotSupportedAnymore, ":#{option} option should be under the :scheduler: key"
-          end
+        if sidekiq_config.key?(option)
+          raise OptionNotSupportedAnymore, ":#{option} option should be under the :scheduler: key"
         end
       end
     end
 
     def self.start_schedule_manager(sidekiq_config:, schedule_manager:)
-      if SIDEKIQ_GTE_6_5_0
-        sidekiq_config[:schedule_manager] = schedule_manager
-        sidekiq_config[:schedule_manager].start
-      else
-        sidekiq_config.options[:schedule_manager] = schedule_manager
-        sidekiq_config.options[:schedule_manager].start
-      end
+      sidekiq_config[:schedule_manager] = schedule_manager
+      sidekiq_config[:schedule_manager].start
     end
 
     def self.stop_schedule_manager(sidekiq_config:)
-      if SIDEKIQ_GTE_6_5_0
-        sidekiq_config[:schedule_manager].stop
-      else
-        sidekiq_config.options[:schedule_manager].stop
-      end
+      sidekiq_config[:schedule_manager].stop
     end
 
     def self.sidekiq_queues(sidekiq_config)
-      if SIDEKIQ_GTE_7_0_0
-        if sidekiq_config.nil? || (sidekiq_config.respond_to?(:empty?) && sidekiq_config.empty?)
-          Sidekiq.instance_variable_get(:@config).queues.map(&:to_s)
-        else
-          sidekiq_config.queues.map(&:to_s)
-        end
-      elsif SIDEKIQ_GTE_6_5_0
-        Sidekiq[:queues].map(&:to_s)
+      if sidekiq_config.nil? || (sidekiq_config.respond_to?(:empty?) && sidekiq_config.empty?)
+        Sidekiq.instance_variable_get(:@config).queues.map(&:to_s)
       else
-        Sidekiq.options[:queues].map(&:to_s)
+        sidekiq_config.queues.map(&:to_s)
       end
     end
 
     def self.redis_key_exists?(key_name)
       Sidekiq.redis do |r|
-        if SIDEKIQ_GTE_7_0_0
-          r.exists(key_name) > 0
-        else
-          r.exists?(key_name)
-        end
+        r.exists(key_name) > 0
       end
     end
 
     def self.redis_zrangebyscore(key, from, to)
       Sidekiq.redis do |r|
-        if SIDEKIQ_GTE_7_0_0
-          r.zrange(key, from, to, "BYSCORE")
-        else
-          r.zrangebyscore(key, from, to)
-        end
+        r.zrange(key, from, to, "BYSCORE")
       end
     end
   end

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  s.add_dependency 'sidekiq', '>= 6', '< 8'
+  s.add_dependency 'sidekiq', '>= 7.3', '< 8'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
 
   s.add_development_dependency 'rake', '~> 12.0'
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activejob'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rack', '< 3'
+  s.add_development_dependency 'rack-session'
 end

--- a/spec/sidekiq-scheduler/scheduler_initialize_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_initialize_spec.rb
@@ -1,17 +1,15 @@
-if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_0_0
-  require 'sidekiq/capsule'
-  
-  describe SidekiqScheduler::Scheduler do
-    it "loads schedule" do
-      Sidekiq.schedule = {
-        "hello_world" => {
-          "class"=> "HelloWorld",
-          "description"=>"Testing out scheduled jobs",
-          "cron"=>"0 12 * * * America/New_York"
-        }
+require 'sidekiq/capsule'
+
+describe SidekiqScheduler::Scheduler do
+  it "loads schedule" do
+    Sidekiq.schedule = {
+      "hello_world" => {
+        "class"=> "HelloWorld",
+        "description"=>"Testing out scheduled jobs",
+        "cron"=>"0 12 * * * America/New_York"
       }
-      SidekiqScheduler::Scheduler.instance.enabled = true
-      SidekiqScheduler::Scheduler.instance.reload_schedule!
-    end
+    }
+    SidekiqScheduler::Scheduler.instance.enabled = true
+    SidekiqScheduler::Scheduler.instance.reload_schedule!
   end
 end

--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -1,5 +1,6 @@
 require 'sidekiq-scheduler/web'
 require 'rack/test'
+require 'rack/session'
 
 describe Sidekiq::Web do
   include Rack::Test::Methods

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -11,32 +11,17 @@ def reset_sidekiq_config!(options={})
 end
 
 def sidekiq_config_for_options(options = {})
-  if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_0_0
-    Sidekiq::Config.new(options)
-  else
-    Sidekiq.options = Sidekiq::DEFAULTS.dup.merge(options)
-    Sidekiq
-  end
+  Sidekiq::Config.new(options)
 end
 
 class SConfigWrapper
   def reset!(options={})
-    if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_0_0
-      @sconfig = reset_sidekiq_config!(options)
-      @sconfig.queues = []
-      @sconfig
-    else
-      # Sidekiq 6 -> reset the sidekiq config for each test
-      Sidekiq.options = Sidekiq::DEFAULTS.dup.merge(options)
-      Sidekiq
-    end
+    @sconfig = reset_sidekiq_config!(options)
+    @sconfig.queues = []
+    @sconfig
   end
 
   def queues=(val)
-    if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_0_0
-      @sconfig.queues = val
-    else
-      Sidekiq.options[:queues] = val
-    end
+    @sconfig.queues = val
   end
 end

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -63,7 +63,7 @@ module SidekiqScheduler
 
     def self.hexists(hash_key, field_key)
       result = Sidekiq.redis { |r| r.hexists(hash_key.to_s, field_key.to_s) }
-      SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_0_0 ? (result > 0) : result
+      result > 0
     end
   end
 end

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -1,8 +1,4 @@
-<% if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_7_3_0 %>
 <%= style_tag "recurring_jobs/stylesheets-scheduler/recurring_jobs.css" %>
-<% else %>
-<link href="<%= root_path %>recurring_jobs/stylesheets-scheduler/recurring_jobs.css" media="screen" rel="stylesheet" type="text/css" />
-<% end %>
 
 <div class="row">
   <div class="col-sm-6">


### PR DESCRIPTION
Figured we may as well get the ball rolling.

This removes checks for older Sidekiq versions leaving support for only Sidekiq 7.3 which still has a level of support.