### PR TITLE
Sidekiq::Web v7.3.0-v7.3.6 does not have configure

### DIFF
--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -1,13 +1,22 @@
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 
 # Locale and asset cache is configured in `cfg.register`
-Sidekiq::Web.configure do |cfg|
-  cfg.register(SidekiqScheduler::Web,
-    name: "recurring_jobs",
-    tab: ["Recurring Jobs"],
-    index: ["recurring-jobs"],
-    root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
-    asset_paths: ["stylesheets-scheduler"]) do |app|
+args = {
+  name: "recurring_jobs",
+  tab: ["Recurring Jobs"],
+  index: ["recurring-jobs"],
+  root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
+  asset_paths: ["stylesheets-scheduler"]
+}
+
+if SidekiqScheduler::SidekiqAdapter::SIDEKIQ_GTE_8_0_0
+  Sidekiq::Web.configure do |cfg|
+    cfg.register(SidekiqScheduler::Web, **args) do |app|
+      # add middleware or additional settings here
+    end
+  end
+else
+  Sidekiq::Web.register(SidekiqScheduler::Web, **args) do |app|
     # add middleware or additional settings here
   end
 end


### PR DESCRIPTION
We're currently using Sidekiq v7.3.3, and in verifying upgrading sidekiq-scheduler to the latest version we got this error:

```
Original Error: NoMethodError vendor/bundle/ruby/3.3.0/gems/sidekiq-scheduler-6.0.0/lib/sidekiq-scheduler/extensions/web.rb:4:in `<main>': undefined method `configure' for class Sidekiq::Web (NoMethodError)

Sidekiq::Web.configure do |cfg|
            ^^^^^^^^^^
        from sidekiq-scheduler-6.0.0/lib/sidekiq-scheduler/web.rb:59:in `require_relative'
        from sidekiq-scheduler-6.0.0/lib/sidekiq-scheduler/web.rb:59:in `<main>'
```

This fixes for Sidekiq::Web < v7.3.7.

Upgrading Sidekiq is substantially more risky due to the number of jobs, which is why we are slightly behind.

Given it was only a few months ago, I figure there might be other apps in a similar situation, but I understand if you don't want to maintain this we can always monkey-patch Sidekiq::Web like the commit below:

See: sidekiq/sidekiq@cf7a879