### PR TITLE
Avoid symbolizing args hash

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -348,11 +348,7 @@ module SidekiqScheduler
     def prepare_arguments(config)
       config['class'] = SidekiqScheduler::Utils.try_to_constantize(config['class'])
 
-      if config['args'].is_a?(Hash)
-        config['args'].symbolize_keys! if config['args'].respond_to?(:symbolize_keys!)
-      else
-        config['args'] = Array(config['args'])
-      end
+      config['args'] = Array(config['args']) unless config['args'].is_a?(Hash)
 
       config
     end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -193,6 +193,20 @@ describe SidekiqScheduler::Scheduler do
       end
     end
 
+    context 'when arguments contain a hash' do
+      let(:args) { { 'dir' => '/tmp', file: 'test.txt' } }
+
+      it 'passes the args hash as is' do
+        expect(Sidekiq::Client).to receive(:push).with({
+                                                         'class' => SomeWorker,
+                                                         'queue' => 'high',
+                                                         'args' => { 'dir' => '/tmp', file: 'test.txt' }
+                                                       })
+
+        subject
+      end
+    end
+
     context 'when job is configured to receive metadata' do
       before { scheduled_job_config['include_metadata'] = true }
 
@@ -252,7 +266,7 @@ describe SidekiqScheduler::Scheduler do
             expect(Sidekiq::Client).to receive(:push).with({
                                                              'class' => SomeWorker,
                                                              'queue' => 'high',
-                                                             'args' => [{ dir: '/tmp' },
+                                                             'args' => [{ 'dir' => '/tmp' },
                                                                         { 'scheduled_at' => schedule_time.to_f.round(3) }]
                                                            })
 

--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -38,8 +38,13 @@ describe Sidekiq::Web do
     if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('8.0.0')
       Sidekiq::Web.configure do |c|
         # Remove CSRF protection
-        # See: https://github.com/sidekiq/sidekiq/blob/0a1bce30e562357e0bb60ce84d78fe5d8446bed9/test/webext_test.rb#L37
-        c.middlewares.clear
+        if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('8.0.5')
+          # See: https://github.com/sidekiq/sidekiq/commit/01bc5c963d9927ff27c62b118196972486a8f9a4
+          c[:csrf] = false
+        else
+          # See: https://github.com/sidekiq/sidekiq/blob/0a1bce30e562357e0bb60ce84d78fe5d8446bed9/test/webext_test.rb#L37
+          c.middlewares.clear
+        end
       end
     end
   end


### PR DESCRIPTION
Addresses Issue #507. Specifically, sidekiq does not support symbolized keys anymore.

It seems that the forced symbolization was meant for ActiveJob, but this appears to already be separately handled in [initialize_active_job](https://github.com/sidekiq-scheduler/sidekiq-scheduler/blob/d06a3e53745ae8d5130c204a86b07aeace79585a/lib/sidekiq-scheduler/utils.rb#L63-L71).

Also fixed an issue I was having with web tests passing for sidekiq >= 8.0.5 (specifically, testing with 8.0.9).