### PR TITLE
Fix Sidekiq 8.1.3 web locale parsing for recurring jobs

### DIFF
--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -3,7 +3,7 @@ require 'sidekiq/web' unless defined?(Sidekiq::Web)
 # Locale and asset cache is configured in `cfg.register`
 args = {
   name: "recurring_jobs",
-  tab: ["Recurring Jobs"],
+  tab: ["recurring_jobs"],
   index: ["recurring-jobs"],
   root_dir: File.expand_path("../../../web", File.dirname(__FILE__)),
   asset_paths: ["stylesheets-scheduler"]

--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -49,6 +49,24 @@ describe Sidekiq::Web do
     end
   end
 
+  describe 'GET /' do
+    subject { get '/' }
+
+    it { is_expected.to be_successful }
+
+    describe 'response body' do
+      subject do
+        get '/'
+        last_response.body
+      end
+
+      it 'shows the recurring jobs tab' do
+        is_expected.to match(/Recurring Jobs/)
+        is_expected.to match(%r{recurring-jobs})
+      end
+    end
+  end
+
   describe 'GET /recurring-jobs' do
     subject { get '/recurring-jobs' }
 
@@ -73,7 +91,7 @@ describe Sidekiq::Web do
           is_expected.to match(/BarClass/)
           is_expected.to match(/1h/)
           is_expected.to match(/special/)
-          is_expected.to match(/\[\"foo\", \"bar\"\]/)
+          is_expected.to match(/\["foo", "bar"\]/)
 
           is_expected.to match(/Enqueue now/)
         end

--- a/web/locales/cs.yml
+++ b/web/locales/cs.yml
@@ -1,5 +1,4 @@
 cs:
-  "Recurring Jobs": Pravidelně opakované
   recurring_jobs: Pravidelně opakované
   name: Jméno
   description: Popis

--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -1,5 +1,4 @@
 de:
-  "Recurring Jobs": Wiederkehrende Jobs
   recurring_jobs: Wiederkehrende Jobs
   name: Name
   description: Beschreibung

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -1,5 +1,4 @@
 en:
-  "Recurring Jobs": Recurring Jobs
   recurring_jobs: Recurring Jobs
   name: Name
   description: Description

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -1,5 +1,4 @@
 es:
-  "Recurring Jobs": Tareas Recurrentes
   recurring_jobs: Tareas Recurrentes
   name: Nombre
   description: Descripción

--- a/web/locales/fr.yml
+++ b/web/locales/fr.yml
@@ -1,5 +1,4 @@
 fr:
-  "Recurring Jobs": Tâches récurrentes
   recurring_jobs: Tâches récurrentes
   name: Nom
   description: Description

--- a/web/locales/gd.yml
+++ b/web/locales/gd.yml
@@ -1,5 +1,4 @@
-﻿gd:
-  "Recurring Jobs": Obraichean ath-chùrsach
+gd:
   recurring_jobs: Obraichean ath-chùrsach
   name: Ainm
   description: Tuairisgeul

--- a/web/locales/it.yml
+++ b/web/locales/it.yml
@@ -1,5 +1,4 @@
 it:
-  "Recurring Jobs": Job ricorrenti
   recurring_jobs: Job ricorrenti
   name: Nome
   description: Descrizione

--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -1,5 +1,4 @@
 ja:
-  "Recurring Jobs": 定期ジョブ
   recurring_jobs: 定期ジョブ
   name: 名前
   description: 説明

--- a/web/locales/nl.yml
+++ b/web/locales/nl.yml
@@ -1,5 +1,4 @@
 nl:
-  "Recurring Jobs": Herhalende taken
   recurring_jobs: Herhalende taken
   name: Naam
   description: Beschrijving

--- a/web/locales/pl.yml
+++ b/web/locales/pl.yml
@@ -1,5 +1,4 @@
 pl:
-  "Recurring Jobs": Okresowe
   recurring_jobs: Okresowe
   name: Nazwa
   description: Opis

--- a/web/locales/pt-BR.yml
+++ b/web/locales/pt-BR.yml
@@ -1,5 +1,4 @@
 pt-BR:
-  "Recurring Jobs": Jobs Recorrentes
   recurring_jobs: Jobs Recorrentes
   name: Nome
   description: Descrição

--- a/web/locales/ru.yml
+++ b/web/locales/ru.yml
@@ -1,5 +1,4 @@
 ru:
-  "Recurring Jobs": Расписание задач
   recurring_jobs: Расписание задач
   name: Название
   description: Описание

--- a/web/locales/sv.yml
+++ b/web/locales/sv.yml
@@ -1,5 +1,4 @@
 sv:
-  "Recurring Jobs": Återkommande jobb
   recurring_jobs: Återkommande jobb
   name: Namn
   description: Beskrivning

--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -1,5 +1,4 @@
 zh-cn:
-  "Recurring Jobs": 周期作业
   recurring_jobs: 周期作业
   name: 名称
   description: 描述


### PR DESCRIPTION
## Summary
- switch the scheduler web tab to the existing `recurring_jobs` translation key instead of the parser-incompatible `\"Recurring Jobs\"` key
- remove the duplicated quoted key from the shipped web locale files and strip the `gd.yml` BOM that also breaks Sidekiq 8.1.3's manual locale parser
- add a dashboard regression spec that proves `GET /` renders the recurring jobs tab under the affected Sidekiq web path

## Verification
- `mise exec ruby@3.4.3 -- env SIDEKIQ_VERSION='= 8.1.3' RACK_VERSION='>= 3.1.0' bundle exec rspec spec/sidekiq-scheduler/web_spec.rb:52 spec/sidekiq-scheduler/web_spec.rb:70`
- `mise exec ruby@3.4.3 -- env SIDEKIQ_VERSION='~> 7.3' RACK_VERSION='~> 2.2' bundle exec rspec spec/sidekiq-scheduler/web_spec.rb:52 spec/sidekiq-scheduler/web_spec.rb:70`

refs https://github.com/sidekiq-scheduler/sidekiq-scheduler/issues/514