### PR TITLE
Fix rubygems sidebar URLs pointing to non-existing moove-it org

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.metadata = { 'rubygems_mfa_required' => 'true' }
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => 'https://github.com/sidekiq-scheduler/sidekiq-scheduler',
+    'bug_tracker_uri' => 'https://github.com/sidekiq-scheduler/sidekiq-scheduler/issues',
+    'changelog_uri' => 'https://github.com/sidekiq-scheduler/sidekiq-scheduler/blob/master/CHANGELOG.md'
+  }
 
   s.add_dependency 'sidekiq', '>= 7.3', '< 9'
   s.add_dependency 'rufus-scheduler', '~> 3.2'


### PR DESCRIPTION
- Add `source_code_uri`, `bug_tracker_uri`, and `changelog_uri` metadata to the gemspec
- These fields tell rubygems.org where to link in the sidebar, fixing the broken links that currently point to the old moove-it GitHub organization
- This also fixes dependabot not showing release notes/commits in upgrade PRs

Closes #516 

🤖 Generated with [Claude Code](https://claude.com/claude-code)