### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         sidekiq-version: ['~> 7.3', '~> 8.0']
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
         rack-version: ['>= 3.1.0']
         include:
           # Sidekiq 8 requires Ruby >= 3.2 and rack >= 3.1

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rufus-scheduler', '~> 3.2'
 
   s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'ostruct'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'ostruct'
+  s.add_development_dependency 'rdoc'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
## Summary
Add Ruby 4.0 to the CI test matrix and update the gemspec to keep the test suite passing under Ruby 4.0.

## Why `ostruct` and `rdoc` are needed
Starting with Ruby 4.0, `ostruct` and `rdoc` have been demoted from default gems to bundled gems ([stdgems.org: ostruct](https://stdgems.org/ostruct/), [stdgems.org: rdoc](https://stdgems.org/rdoc/)). Bundled gems are still shipped with Ruby, but under Bundler they must be declared explicitly in the Gemfile/gemspec ([RubyGems Guides: Default Gems and Bundled Gems](https://guides.rubygems.org/default-gems-and-bundled-gems/)).