### PR TITLE
Batch recurring job metadata reads

### DIFF
--- a/lib/sidekiq-scheduler/job_presenter.rb
+++ b/lib/sidekiq-scheduler/job_presenter.rb
@@ -11,16 +11,19 @@ module SidekiqScheduler
 
     include Sidekiq::WebHelpers
 
-    def initialize(name, attributes)
+    def initialize(name, attributes, metadata: nil)
       @name = name
       @attributes = attributes
+      @metadata = metadata
+      @state = metadata&.fetch(:state)
+      @state = @state ? JSON.parse(@state) : {} if metadata
     end
 
     # Returns the next time execution for the job
     #
     # @return [String] with the job's next time
     def next_time
-      execution_time = SidekiqScheduler::RedisManager.get_job_next_time(name)
+      execution_time = @metadata ? @metadata[:next_time] : SidekiqScheduler::RedisManager.get_job_next_time(name)
 
       relative_time(Time.parse(execution_time)) if execution_time
     end
@@ -29,7 +32,7 @@ module SidekiqScheduler
     #
     # @return [String] with the job's last time
     def last_time
-      execution_time = SidekiqScheduler::RedisManager.get_job_last_time(name)
+      execution_time = @metadata ? @metadata[:last_time] : SidekiqScheduler::RedisManager.get_job_last_time(name)
 
       relative_time(Time.parse(execution_time)) if execution_time
     end
@@ -56,7 +59,9 @@ module SidekiqScheduler
     end
 
     def enabled?
-      SidekiqScheduler::Scheduler.job_enabled?(@name)
+      return SidekiqScheduler::Scheduler.job_enabled?(@name) unless @metadata
+
+      @state.fetch('enabled', @attributes.fetch('enabled', true))
     end
 
     # Builds the presenter instances for the schedule hash
@@ -65,9 +70,11 @@ module SidekiqScheduler
     # @return [Array<JobPresenter>] an array with the instances of presenters
     def self.build_collection(schedule_hash)
       schedule_hash ||= {}
+      job_names = schedule_hash.keys.sort
+      metadata = SidekiqScheduler::RedisManager.get_jobs_metadata(job_names)
 
-      schedule_hash.sort.map do |name, job_spec|
-        new(name, job_spec)
+      job_names.map do |name|
+        new(name, schedule_hash.fetch(name), metadata: metadata.fetch(name))
       end
     end
   end

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -39,6 +39,27 @@ module SidekiqScheduler
       hget(last_times_key, name)
     end
 
+    # Returns the state and execution times for the given jobs.
+    #
+    # @param [Array<String>] names job names
+    # @return [Hash] metadata keyed by job name
+    def self.get_jobs_metadata(names)
+      names = Array(names)
+      return {} if names.empty?
+
+      states, last_times, next_times = Sidekiq.redis do |redis|
+        redis.pipelined do |pipeline|
+          pipeline.hmget(schedules_state_key, *names)
+          pipeline.hmget(last_times_key, *names)
+          pipeline.hmget(next_times_key, *names)
+        end
+      end
+
+      names.each_with_index.to_h do |name, index|
+        [name, { state: states[index], last_time: last_times[index], next_time: next_times[index] }]
+      end
+    end
+
     # Sets the schedule for a given job
     #
     # @param [String] name The name of the job

--- a/spec/sidekiq-scheduler/job_presenter_spec.rb
+++ b/spec/sidekiq-scheduler/job_presenter_spec.rb
@@ -121,5 +121,38 @@ describe SidekiqScheduler::JobPresenter do
         expect(subject.map(&:name)).to eq([:a_job, :b_job, :c_job, :d_job])
       end
     end
+
+    context 'when jobs have stored metadata' do
+      let(:schedule_hash) do
+        {
+          'enabled_job' => { 'enabled' => true },
+          'disabled_job' => { 'enabled' => true }
+        }
+      end
+      let(:last_time) { Time.now - 60 }
+      let(:next_time) { Time.now + 60 }
+
+      before do
+        SidekiqScheduler::RedisManager.set_job_state('disabled_job', 'enabled' => false)
+        SidekiqScheduler::RedisManager.set_job_last_time('disabled_job', last_time)
+        SidekiqScheduler::RedisManager.set_job_next_time('disabled_job', next_time)
+      end
+
+      it 'preloads metadata for every presenter' do
+        expect(SidekiqScheduler::RedisManager).to receive(:get_jobs_metadata)
+          .once.with(%w(disabled_job enabled_job)).and_call_original
+
+        presenters = subject.to_h { |presenter| [presenter.name, presenter] }
+
+        expect(SidekiqScheduler::RedisManager).not_to receive(:get_job_state)
+        expect(SidekiqScheduler::RedisManager).not_to receive(:get_job_last_time)
+        expect(SidekiqScheduler::RedisManager).not_to receive(:get_job_next_time)
+
+        expect(presenters.fetch('disabled_job').enabled?).to be(false)
+        expect(presenters.fetch('disabled_job').last_time).to eq(job_presenter.relative_time(last_time))
+        expect(presenters.fetch('disabled_job').next_time).to eq(job_presenter.relative_time(next_time))
+        expect(presenters.fetch('enabled_job').enabled?).to be(true)
+      end
+    end
   end
 end

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -49,6 +49,40 @@ describe SidekiqScheduler::RedisManager do
     it { is_expected.to eq(last_time) }
   end
 
+  describe '.get_jobs_metadata' do
+    subject { described_class.get_jobs_metadata(job_names) }
+
+    let(:job_names) { %w(some_job missing_job) }
+    let(:state) { JSON.generate('enabled' => false) }
+    let(:last_time) { 'last_time' }
+    let(:next_time) { 'next_time' }
+
+    before do
+      SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.schedules_state_key, 'some_job', state)
+      SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.last_times_key, 'some_job', last_time)
+      SidekiqScheduler::Store.hset(SidekiqScheduler::RedisManager.next_times_key, 'some_job', next_time)
+    end
+
+    it 'returns all metadata with one Redis checkout' do
+      expect(Sidekiq).to receive(:redis).once.and_call_original
+
+      is_expected.to eq(
+        'some_job' => { state: state, last_time: last_time, next_time: next_time },
+        'missing_job' => { state: nil, last_time: nil, next_time: nil }
+      )
+    end
+
+    context 'without job names' do
+      let(:job_names) { [] }
+
+      it 'does not access Redis' do
+        expect(Sidekiq).not_to receive(:redis)
+
+        is_expected.to eq({})
+      end
+    end
+  end
+
   describe '.set_job_schedule' do
     subject { described_class.set_job_schedule(job_name, config) }
 

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -14,7 +14,8 @@
 
   <section class="job-list">
     <% @presented_jobs.each do |job| %>
-      <section class="job <%= job.enabled? ? "" : "disabled-job" %>">
+      <% job_enabled = job.enabled? %>
+      <section class="job <%= job_enabled ? "" : "disabled-job" %>">
         <div class="row">
           <div class="column-2">
             <div class="job-name"><%= job.name %></div>
@@ -43,7 +44,7 @@
             </form>
             <form class="inline" action="<%= root_path %>recurring-jobs/<%= ERB::Util.url_encode(job.name) %>/toggle" method="POST">
               <%= csrf_tag %>
-              <input type="submit" class="btn btn-xs <%= job.enabled? ? "btn-inverse" : "btn-warn"%>" value="<%= job.enabled? ? t('disable') : t('enable') %>" />
+              <input type="submit" class="btn btn-xs <%= job_enabled ? "btn-inverse" : "btn-warn"%>" value="<%= job_enabled ? t('disable') : t('enable') %>" />
             </form>
           </div>
           <div class="column-3">

--- a/web/views/sidekiq73/recurring_jobs.erb
+++ b/web/views/sidekiq73/recurring_jobs.erb
@@ -16,7 +16,8 @@
 <div class="recurring-jobs">
   <ul class="list-group">
     <% @presented_jobs.each do |job| %>
-      <li class="list-group-item <%= !job.enabled? && "list-group-item-disabled" %>">
+      <% job_enabled = job.enabled? %>
+      <li class="list-group-item <%= !job_enabled && "list-group-item-disabled" %>">
         <div class="title">
           <div class="row">
             <div class="col-xs-6">
@@ -43,14 +44,14 @@
             </form>
             <form action="<%= root_path %>recurring-jobs/<%= ERB::Util.url_encode(job.name) %>/toggle" method="post">
               <%= csrf_tag %>
-              <input type="submit" class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" value="<%= job.enabled? ? t('disable') : t('enable') %>" />
+              <input type="submit" class="btn <%= job_enabled ? "btn-primary" : "btn-warn"%> btn-xs" value="<%= job_enabled ? t('disable') : t('enable') %>" />
             </form>
           </div>
           <div class="col-md-4">
             <span class="last_time"><%= t('last_time') %>: <%= job.last_time %></span>
           </div>
           <div class="col-md-4">
-            <span class="next_time text-right" style="<%= 'text-decoration:line-through' unless job.enabled? %>">
+            <span class="next_time text-right" style="<%= 'text-decoration:line-through' unless job_enabled %>">
               <%= t('next_time') %>: <%= job.next_time || t('no_next_time') %>
             </span>
           </div>


### PR DESCRIPTION
## Summary

- batch recurring-job state, last-run, and next-run reads into one Redis pipeline
- pass the preloaded metadata into each `JobPresenter` while preserving the existing direct-instantiation fallback
- evaluate `enabled?` once per row in both supported Sidekiq Web templates

## Why

The recurring jobs page currently reads Redis separately every time a presenter renders its enabled state, last execution time, or next execution time. The Sidekiq 8 template calls `enabled?` three times per job, so a page with 236 recurring jobs performs about 1,180 presenter-level Redis reads.

This change replaces those per-job reads with three `HMGET` commands sent through one pipeline. Directly instantiated presenters retain the existing behavior and continue loading their own values from Redis.

## Validation

- Sidekiq 8 / Rack 3 full suite: 277 examples, 0 failures
- Sidekiq 7.3 / Rack 2.2 focused Redis manager, presenter, and web specs: 68 examples, 0 failures
- Ruby syntax and `git diff --check`
