### PR TITLE
Apply listened_queues_only to dynamic schedule updates

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -97,11 +97,7 @@ module SidekiqScheduler
         queues = scheduler_config.sidekiq_queues
 
         Sidekiq.schedule.each do |name, config|
-          if !listened_queues_only || enabled_queue?(config['queue'].to_s, queues)
-            load_schedule_job(name, config)
-          else
-            Sidekiq.logger.info { "Ignoring #{name}, job's queue is not enabled." }
-          end
+          load_schedule_job_for_queues(name, config, queues)
         end
 
         Sidekiq.logger.info 'Schedules Loaded'
@@ -219,10 +215,11 @@ module SidekiqScheduler
         Sidekiq.logger.info 'Updating schedule'
 
         Sidekiq.reload_schedule!
+        queues = scheduler_config.sidekiq_queues
         schedule_changes.each do |schedule_name|
           if Sidekiq.schedule.keys.include?(schedule_name)
             unschedule_job(schedule_name)
-            load_schedule_job(schedule_name, Sidekiq.schedule[schedule_name])
+            load_schedule_job_for_queues(schedule_name, Sidekiq.schedule[schedule_name], queues)
           else
             unschedule_job(schedule_name)
           end
@@ -263,6 +260,14 @@ module SidekiqScheduler
     private
 
     attr_reader :scheduler_config
+
+    def load_schedule_job_for_queues(name, config, queues)
+      if !listened_queues_only || enabled_queue?(config['queue'].to_s, queues)
+        load_schedule_job(name, config)
+      else
+        Sidekiq.logger.info { "Ignoring #{name}, job's queue is not enabled." }
+      end
+    end
 
     def new_job(name, interval_type, config, schedule, options)
       options = options.merge({ :job => true, :tags => [name] })


### PR DESCRIPTION
## Summary
Use the same queue-filtering helper for initial loading and dynamic changes. Compute the configured queues once per batch, and keep the existing unschedule-before-reload behavior so moving a job to an excluded queue removes it.

Fixes #521. The issue includes reproduction steps and original behavior.

## Verification
- Ruby 4.0.6, Sidekiq 8.1.7, Rack 3.2.7 and Rufus 3.9.2.
- Initial excluded job stays excluded after polling; moving it to an allowed queue adds it; moving it back removes it. Empty configured queues still allow all jobs, and deletion removes the schedule. Existing disabled-filter behavior stays unchanged.
- Full existing upstream RSpec suite on the unchanged master baseline and this individual patch: **277 examples, 0 failures**.
- Reproductions use bounded future schedules and shut down their Rufus instances; Redis is a disposable local service over a private Unix socket.
- Ruby syntax and whitespace checks pass. Targeted Lint checks use a temporary external configuration, excluding two pre-existing offenses in unchanged code (NonLocalExitFromIterator and UselessConstantScoping). No upstream lint configuration changed.

## Compatibility and limitations
No intended breaking changes. No runtime dependency or version changes. Other Sidekiq/Ruby/platform combinations and upstream CI are not yet verified locally for this individual patch. No test files added or modified, per the originating project's policy; focused repros ran outside the repository.

Prepared with Codex assistance. Findings were reproduced locally; no production access or deployment was used.
