### PR TITLE
Commit the dynamic schedule cursor after successful updates

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -212,8 +212,8 @@ module SidekiqScheduler
     end
 
     def update_schedule
-      last_changed_score, @current_changed_score = @current_changed_score, Time.now.to_f
-      schedule_changes = SidekiqScheduler::RedisManager.get_schedule_changes(last_changed_score, @current_changed_score)
+      current_changed_score = Time.now.to_f
+      schedule_changes = SidekiqScheduler::RedisManager.get_schedule_changes(@current_changed_score, current_changed_score)
 
       if schedule_changes.size > 0
         Sidekiq.logger.info 'Updating schedule'
@@ -229,6 +229,8 @@ module SidekiqScheduler
         end
         Sidekiq.logger.info 'Schedule updated'
       end
+
+      @current_changed_score = current_changed_score
     end
 
     def job_enabled?(name)


### PR DESCRIPTION
## Summary
Keep the poll upper bound local until the Redis read, reload and all changed-job applications succeed. Only then assign the next cursor.

Fixes #522. The issue includes reproduction steps and original behavior.

## Verification
- Ruby 4.0.6, Sidekiq 8.1.7, Rack 3.2.7 and Rufus 3.9.2.
- A one-shot simulated Redis read failure previously advanced the cursor and lost an added schedule. The patch preserves the previous cursor; the following successful poll loads the missed job. This permits replay after partial failure, not atomic multi-job scheduling or exactly-once execution.
- Full existing upstream RSpec suite on the unchanged master baseline and this individual patch: **277 examples, 0 failures**.
- Reproductions use bounded future schedules and shut down their Rufus instances; Redis is a disposable local service over a private Unix socket.
- Ruby syntax and whitespace checks pass. Targeted Lint checks use a temporary external configuration, excluding two pre-existing offenses in unchanged code (NonLocalExitFromIterator and UselessConstantScoping). No upstream lint configuration changed.

## Compatibility and limitations
No intended breaking changes. No runtime dependency or version changes. Other Sidekiq/Ruby/platform combinations and upstream CI are not yet verified locally for this individual patch. No test files added or modified, per the originating project's policy; focused repros ran outside the repository.

Prepared with Codex assistance. Findings were reproduced locally; no production access or deployment was used.
