### PR TITLE
Isolate mutable default scheduler configuration hashes

### DIFF
--- a/lib/sidekiq-scheduler/config.rb
+++ b/lib/sidekiq-scheduler/config.rb
@@ -85,7 +85,7 @@ module SidekiqScheduler
 
     def fetch_scheduler_config(sidekiq_config, without_defaults)
       conf = SidekiqScheduler::SidekiqAdapter.fetch_scheduler_config_from_sidekiq(sidekiq_config)
-      without_defaults ? conf : DEFAULT_OPTIONS.merge(conf)
+      without_defaults ? conf : DEFAULT_OPTIONS.merge({ schedule: {}, rufus_scheduler_options: {} }, conf)
     end
   end
 end


### PR DESCRIPTION
## Summary
Allocate fresh default schedule and Rufus option hashes before overlaying explicit configuration. Keep the other defaults and without_defaults behavior unchanged.

Fixes #523. The issue includes reproduction steps and original behavior.

## Verification
- Ruby 4.0.6, Sidekiq 8.1.7, Rack 3.2.7 and Rufus 3.9.2.
- Mutating one default Config no longer changes a later instance's schedule or max_work_threads. This is limited to defaults; it does not deep-copy caller-supplied hashes.
- Full existing upstream RSpec suite on the unchanged master baseline and this individual patch: **277 examples, 0 failures**.
- Reproductions use bounded future schedules and shut down their Rufus instances; Redis is a disposable local service over a private Unix socket.
- Ruby syntax and whitespace checks pass. Targeted Lint checks use a temporary external configuration, excluding two pre-existing offenses in unchanged code (NonLocalExitFromIterator and UselessConstantScoping). No upstream lint configuration changed.

## Compatibility and limitations
No intended breaking changes. No runtime dependency or version changes. Other Sidekiq/Ruby/platform combinations and upstream CI are not yet verified locally for this individual patch. No test files added or modified, per the originating project's policy; focused repros ran outside the repository.

Prepared with Codex assistance. Findings were reproduced locally; no production access or deployment was used.
