### PR TITLE
Stop managers without restarting the Rufus scheduler

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -17,7 +17,7 @@ module SidekiqScheduler
     end
 
     def stop
-      @scheduler_instance.clear_schedule!
+      @scheduler_instance.clear_schedule!(restart: false)
     end
 
     def start

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -186,11 +186,12 @@ module SidekiqScheduler
       @rufus_scheduler ||= SidekiqScheduler::Utils.new_rufus_scheduler(rufus_scheduler_options)
     end
 
-    # Stops old rufus scheduler and creates a new one.  Returns the new
-    # rufus scheduler
+    # Stops old rufus scheduler and optionally creates a new one. Returns the new
+    # rufus scheduler when restarting.
     #
     # @param [Symbol] stop_option The option to be passed to Rufus::Scheduler#stop
-    def clear_schedule!(stop_option = :wait)
+    # @param [Boolean] restart Whether to create a new scheduler after stopping
+    def clear_schedule!(stop_option = :wait, restart: true)
       if @rufus_scheduler
         @rufus_scheduler.stop(stop_option)
         @rufus_scheduler = nil
@@ -198,7 +199,7 @@ module SidekiqScheduler
 
       @scheduled_jobs = {}
 
-      rufus_scheduler
+      rufus_scheduler if restart
     end
 
     def reload_schedule!


### PR DESCRIPTION
## Summary
Add an optional restart: keyword to clear_schedule!, defaulting to true, and pass restart: false from Manager#stop. Preserve the existing positional stop option and normal clear/reload restart contract.

Fixes #524. The issue includes reproduction steps and original behavior.

## Verification
- Ruby 4.0.6, Sidekiq 8.1.7, Rack 3.2.7 and Rufus 3.9.2.
- After starting a future recurring job, stop shuts down the original Rufus scheduler and leaves no replacement running. Repeated stop also leaves none running. Default clear_schedule! still restarts, as covered by the existing suite.
- Full existing upstream RSpec suite on the unchanged master baseline and this individual patch: **277 examples, 0 failures**.
- Reproductions use bounded future schedules and shut down their Rufus instances; Redis is a disposable local service over a private Unix socket.
- Ruby syntax and whitespace checks pass. Targeted Lint checks use a temporary external configuration, excluding two pre-existing offenses in unchanged code (NonLocalExitFromIterator and UselessConstantScoping). No upstream lint configuration changed.

## Compatibility and limitations
No intended breaking changes. The new keyword is optional and existing clear/reload callers retain their documented behavior. No runtime dependency or version changes. Other Sidekiq/Ruby/platform combinations and upstream CI are not yet verified locally for this individual patch. No test files added or modified, per the originating project's policy; focused repros ran outside the repository.

Prepared with Codex assistance. Findings were reproduced locally; no production access or deployment was used.
