### PR TITLE
Use current Rufus APIs when printing schedules

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -70,8 +70,8 @@ module SidekiqScheduler
       if rufus_scheduler
         Sidekiq.logger.info "Scheduling Info\tLast Run"
         scheduler_jobs = rufus_scheduler.jobs
-        scheduler_jobs.each_value do |v|
-          Sidekiq.logger.info "#{v.t}\t#{v.last}\t"
+        scheduler_jobs.each do |job|
+          Sidekiq.logger.info "#{job.original}\t#{job.last_time}\t"
         end
       end
     end


### PR DESCRIPTION
## Summary
- Iterate Rufus's jobs array with `each`.
- Read the supported `original` and `last_time` accessors instead of obsolete `t` and `last` methods.

Fixes #529, which includes the standalone reproduction.

## Verification
- Ruby 4.0.6 / Rufus 3.9.2: empty and populated schedules print successfully after the fix. The installed 6.0.2 release raises `NoMethodError` for `each_value`; iteration alone would still leave both obsolete accessors broken.
- Full existing upstream RSpec suite on baseline and this individual patch: **277 examples, 0 failures**, with Sidekiq 8.1.7 / Rack 3.2.7 and disposable local Redis.
- Ruby syntax and whitespace checks pass. No test files added or modified, per the originating project's policy; the standalone reproduction ran outside the repository.

## Compatibility and limitations
No intended breaking changes. The diagnostic keeps its existing heading and tab-separated schedule/last-run fields, now using the supported Rufus API. No dependency, scheduling or execution changes. Older Ruby/Rufus/platform combinations and upstream CI are not yet verified locally for this individual patch.

Prepared with Codex assistance. No production access or deployment was used.
