### PR TITLE
Clear state when removing schedules

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -76,6 +76,13 @@ module SidekiqScheduler
       hset(schedules_state_key, name, JSON.generate(state))
     end
 
+    # Removes the state for a given job
+    #
+    # @param [String] name The name of the job
+    def self.remove_job_state(name)
+      hdel(schedules_state_key, name)
+    end
+
     # Sets the next execution time for a given job
     #
     # @param [String] name The name of the job

--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -113,6 +113,7 @@ module SidekiqScheduler
     # remove a given schedule by name
     def remove_schedule(name)
       SidekiqScheduler::RedisManager.remove_job_schedule(name)
+      SidekiqScheduler::RedisManager.remove_job_state(name)
       SidekiqScheduler::RedisManager.add_schedule_change(name)
     end
 


### PR DESCRIPTION
Summary

Clear persisted enabled state whenever a schedule is removed. Re-adding the same name then respects the newly configured enabled default instead of reviving an old manual toggle. This addresses #506 for explicit dynamic removal and bulk/static schedule replacement.

Reproduction

Set a disabled schedule, toggle its stored state to enabled, remove it, and re-add it disabled. Before this change the old enabled state wins; afterward removal clears the state and the re-added definition remains disabled.

Verification

Ruby 4.0.6 / Sidekiq 8.1.7: existing 277 examples, zero failures; focused live-Redis explicit and bulk removal/re-add model; syntax and whitespace pass. The release-based consumer suite uses the existing external Sec-Fetch-Site fixture bootstrap required by Sidekiq 8.1. No tests or dependencies changed.

Compatibility

State survives ordinary schedule updates and restarts as before. Only explicit schedule removal now ends that state lifecycle. Prepared with Codex assistance.