### PR TITLE
Avoid allocating schedule key arrays during updates

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -220,7 +220,7 @@ module SidekiqScheduler
 
         Sidekiq.reload_schedule!
         schedule_changes.each do |schedule_name|
-          if Sidekiq.schedule.keys.include?(schedule_name)
+          if Sidekiq.schedule.key?(schedule_name)
             unschedule_job(schedule_name)
             load_schedule_job(schedule_name, Sidekiq.schedule[schedule_name])
           else


### PR DESCRIPTION
Summary

Use Hash#key? for changed-schedule membership instead of allocating and scanning Sidekiq.schedule.keys for every changed job. Closes #532.

Verification

The complete 277-example suite passes. A 10,000-schedule / 1,000-lookup component model measured 0.053227s for keys.include? and 0.000036s for key?, with identical membership results. Syntax and whitespace pass. No tests or dependencies changed.

Compatibility

Sidekiq.schedule is the existing Hash schedule; membership and update behavior are unchanged. The measurement is local component evidence, not a production throughput claim. Prepared with Codex assistance.