### PR TITLE
Add regression coverage for dynamic listened_queues_only filtering

### DIFF
--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -1120,6 +1120,65 @@ describe SidekiqScheduler::Scheduler do
         expect { subject }.to change { instance.instance_variable_get(:@current_changed_score) }.to be_a(Float)
       end
     end
+
+    context 'when listened_queues_only flag is active' do
+      let(:scheduler_options) do
+        {
+          scheduler: {
+            enabled: true,
+            dynamic: true,
+            dynamic_every: '5s',
+            listened_queues_only: true
+          }
+        }
+      end
+
+      before { @sconfig.queues = ['default'] }
+
+      context 'when a new job targets an excluded queue' do
+        before { Sidekiq.set_schedule('excluded_job', ScheduleFaker.cron_schedule('queue' => 'other')) }
+
+        it 'does not load the job into the scheduler' do
+          subject
+          expect(instance.scheduled_jobs.keys).to_not include('excluded_job')
+        end
+      end
+
+      context 'when a new job targets an included queue' do
+        before { Sidekiq.set_schedule('included_job', ScheduleFaker.cron_schedule('queue' => 'default')) }
+
+        it 'loads the job into the scheduler' do
+          subject
+          expect(instance.scheduled_jobs.keys).to include('included_job')
+        end
+      end
+
+      context 'when an existing job moves to an excluded queue' do
+        before do
+          Sidekiq.set_schedule('old_job', ScheduleFaker.cron_schedule('queue' => 'other'))
+        end
+
+        it 'removes the job from the scheduler' do
+          expect(instance.scheduled_jobs.keys).to include('old_job')
+          subject
+          expect(instance.scheduled_jobs.keys).to_not include('old_job')
+        end
+      end
+
+      context 'when an excluded job moves to an included queue' do
+        before do
+          Sidekiq.set_schedule('excluded_job', ScheduleFaker.cron_schedule('queue' => 'other'))
+          instance.update_schedule
+          Sidekiq.set_schedule('excluded_job', ScheduleFaker.cron_schedule('queue' => 'default'))
+        end
+
+        it 'loads the job into the scheduler' do
+          expect(instance.scheduled_jobs.keys).to_not include('excluded_job')
+          subject
+          expect(instance.scheduled_jobs.keys).to include('excluded_job')
+        end
+      end
+    end
   end
 
   describe '#to_hash' do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds regression coverage for #525 / #521 now that the queue-filter fix is on `master`.

`update_schedule` previously bypassed `listened_queues_only`. These specs lock in the intended dynamic behavior:

- new job on an excluded queue is not scheduled
- new job on an included queue is scheduled
- moving a job to an excluded queue unschedules it
- moving an excluded job onto an included queue schedules it

## Test plan
- [x] `bundle exec rspec spec/sidekiq-scheduler/scheduler_spec.rb -e update_schedule` (16 examples, 0 failures)
- [ ] CI matrix on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bc6795-81a1-4042-884d-74e0b5408f45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bc6795-81a1-4042-884d-74e0b5408f45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

