### PR TITLE
Add regression coverage for failed dynamic poll cursor

### DIFF
--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -1121,6 +1121,32 @@ describe SidekiqScheduler::Scheduler do
       end
     end
 
+    context 'when fetching schedule changes fails' do
+      before { Sidekiq.set_schedule('new_job', ScheduleFaker.cron_schedule) }
+
+      it 'does not advance the change cursor' do
+        previous_score = instance.instance_variable_get(:@current_changed_score)
+
+        allow(SidekiqScheduler::RedisManager).to receive(:get_schedule_changes).and_raise(IOError)
+
+        expect { subject }.to raise_error(IOError)
+        expect(instance.instance_variable_get(:@current_changed_score)).to eq(previous_score)
+      end
+
+      it 'loads the missed job on the next successful poll' do
+        allow(SidekiqScheduler::RedisManager).to receive(:get_schedule_changes).and_raise(IOError)
+
+        expect { subject }.to raise_error(IOError)
+        expect(instance.scheduled_jobs.keys).to_not include('new_job')
+
+        allow(SidekiqScheduler::RedisManager).to receive(:get_schedule_changes).and_call_original
+
+        instance.update_schedule
+
+        expect(instance.scheduled_jobs.keys).to include('new_job')
+      end
+    end
+
     context 'when listened_queues_only flag is active' do
       let(:scheduler_options) do
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds regression coverage for the dynamic poll cursor fix from #526 / #522.

When `get_schedule_changes` raises, `@current_changed_score` must stay put so the next successful poll can still load the missed schedule change.

## Test plan
- [x] `bundle exec rspec spec/sidekiq-scheduler/scheduler_spec.rb -e "fetching schedule changes fails"` (2 examples, 0 failures)
- [ ] CI matrix on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bc6795-81a1-4042-884d-74e0b5408f45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bc6795-81a1-4042-884d-74e0b5408f45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

